### PR TITLE
fix: correct ArtifactRef import path and UI module dependencies

### DIFF
--- a/changelog.d/10.fixed.md
+++ b/changelog.d/10.fixed.md
@@ -1,0 +1,1 @@
+Fix `devqubit-ui` standalone installation by importing directly from `devqubit_engine` instead of the `devqubit` metapackage, and fixed `ArtifactRef` lazy import path.

--- a/packages/devqubit-ui/src/devqubit_ui/app.py
+++ b/packages/devqubit-ui/src/devqubit_ui/app.py
@@ -32,14 +32,14 @@ from pathlib import Path
 from typing import AsyncGenerator
 
 import uvicorn
+from devqubit_engine.core.config import Config
+from devqubit_engine.storage.factory import create_registry, create_store
 from devqubit_engine.storage.protocols import ObjectStoreProtocol, RegistryProtocol
 from devqubit_ui.filters import register_filters
 from devqubit_ui.plugins import load_ui_plugins
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-
-from devqubit import Config, create_registry, create_store
 
 
 logger = logging.getLogger(__name__)

--- a/packages/devqubit-ui/src/devqubit_ui/dependencies.py
+++ b/packages/devqubit-ui/src/devqubit_ui/dependencies.py
@@ -24,15 +24,14 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
+from devqubit_engine.core.config import Config
 from devqubit_engine.storage.protocols import ObjectStoreProtocol, RegistryProtocol
 from devqubit_ui.app import templates
 from fastapi import Depends, Request
 from fastapi.templating import Jinja2Templates
 
-from devqubit import Config
 
-
-def get_config(request: Request) -> "Config":
+def get_config(request: Request) -> Config:
     """
     Get the Config instance from application state.
 
@@ -49,7 +48,7 @@ def get_config(request: Request) -> "Config":
     return request.app.state.config
 
 
-def get_registry(request: Request) -> "RegistryProtocol":
+def get_registry(request: Request) -> RegistryProtocol:
     """
     Get the registry instance from application state.
 
@@ -66,7 +65,7 @@ def get_registry(request: Request) -> "RegistryProtocol":
     return request.app.state.registry
 
 
-def get_store(request: Request) -> "ObjectStoreProtocol":
+def get_store(request: Request) -> ObjectStoreProtocol:
     """
     Get the object store instance from application state.
 
@@ -83,7 +82,7 @@ def get_store(request: Request) -> "ObjectStoreProtocol":
     return request.app.state.store
 
 
-def get_templates() -> "Jinja2Templates":
+def get_templates() -> Jinja2Templates:
     """
     Get the Jinja2 templates instance.
 

--- a/packages/devqubit-ui/src/devqubit_ui/services.py
+++ b/packages/devqubit-ui/src/devqubit_ui/services.py
@@ -562,7 +562,7 @@ class DiffService:
             raise KeyError(f"Run B not found: {run_id_b}") from e
 
         # Use devqubit's diff_runs function
-        from devqubit import diff_runs
+        from devqubit_engine.compare.diff import diff_runs
 
         logger.debug("Comparing runs: %s vs %s", run_id_a, run_id_b)
         result = diff_runs(

--- a/src/devqubit/__init__.py
+++ b/src/devqubit/__init__.py
@@ -97,8 +97,9 @@ if TYPE_CHECKING:
     from devqubit_engine.compare.diff import diff, diff_runs
     from devqubit_engine.compare.verify import verify, verify_against_baseline
     from devqubit_engine.core.config import Config, get_config, set_config
-    from devqubit_engine.core.record import ArtifactRef, RunRecord
+    from devqubit_engine.core.record import RunRecord
     from devqubit_engine.core.tracker import Run, track, wrap_backend
+    from devqubit_engine.core.types import ArtifactRef
     from devqubit_engine.storage.factory import create_registry, create_store
     from devqubit_ui.app import run_server
 
@@ -108,7 +109,7 @@ _LAZY_IMPORTS = {
     "track": ("devqubit_engine.core.tracker", "track"),
     "wrap_backend": ("devqubit_engine.core.tracker", "wrap_backend"),
     "RunRecord": ("devqubit_engine.core.record", "RunRecord"),
-    "ArtifactRef": ("devqubit_engine.core.models", "ArtifactRef"),
+    "ArtifactRef": ("devqubit_engine.core.types", "ArtifactRef"),
     "diff": ("devqubit_engine.compare.diff", "diff"),
     "diff_runs": ("devqubit_engine.compare.diff", "diff_runs"),
     "verify": ("devqubit_engine.compare.verify", "verify"),


### PR DESCRIPTION
## Summary
Fixes two import bugs that cause ModuleNotFoundError:
1. `ArtifactRef` lazy import pointed to non-existent `devqubit_engine.core.models` instead of `devqubit_engine.core.types`
2. `devqubit-ui` imported from `devqubit` metapackage instead of `devqubit_engine` directly, breaking standalone UI installation

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no user-facing change)
- [ ] Docs only
- [ ] CI/build tooling
- [ ] Breaking change

## Changelog (user-facing only)
- [x] I added a towncrier fragment in `changelog.d/`

## Checklist
- [x] I ran lint locally (`uv run pre-commit run --all-files`)
- [x] I ran tests locally (`uv run pytest`)
- [ ] I added/updated tests for behavior changes
- [ ] I updated docs/README/examples if needed
- [ ] If I changed dependencies, I updated `uv.lock` (`uv lock`) and committed it
- [x] I considered backward compatibility and security impact

## Notes for reviewers
No breaking changes - these are pure bug fixes. The UI now imports directly from `devqubit_engine` submodules, which avoids potential circular dependency issues.
