### PR TITLE
feat: UEC as source of truth and adapter compliance

### DIFF
--- a/changelog.d/16.changed.md
+++ b/changelog.d/16.changed.md
@@ -1,0 +1,1 @@
+UEC ExecutionEnvelope is now the single source of truth for diffs/verification: adapter runs must emit a schema-valid envelope; “non-strict” fallback/synthesis for adapter runs was removed. Manual/replay runs still synthesize a best-effort envelope. Program comparison now distinguishes structural vs parametric hashes and results are canonicalized across bit orders.

--- a/packages/devqubit-braket/src/devqubit_braket/adapter.py
+++ b/packages/devqubit-braket/src/devqubit_braket/adapter.py
@@ -6,7 +6,7 @@ Braket adapter for devqubit tracking system.
 
 Provides integration with Amazon Braket devices, enabling automatic tracking
 of quantum circuit execution, results, and device configurations using the
-Uniform Execution Contract (UEC) 1.0.
+Uniform Execution Contract (UEC).
 
 Example
 -------
@@ -462,14 +462,23 @@ class TrackedDevice:
         self._execution_count += 1
         exec_count = self._execution_count
 
-        # Compute circuit hash
-        circuit_hash = _compute_structural_hash(circuits_for_logging)
-        is_new_circuit = circuit_hash and circuit_hash not in self._seen_circuit_hashes
-        if circuit_hash:
-            self._seen_circuit_hashes.add(circuit_hash)
+        # Compute hashes
+        # structural_hash: ignores parameter values (for deduplication)
+        # parametric_hash: includes parameter values from inputs (for exact match)
+        structural_hash = _compute_structural_hash(circuits_for_logging)
+
+        # Extract inputs for parametric hash (Braket's FreeParameter bindings)
+        inputs = kwargs.get("inputs")
+        parametric_hash = _compute_parametric_hash(circuits_for_logging, inputs)
+
+        is_new_circuit = (
+            structural_hash and structural_hash not in self._seen_circuit_hashes
+        )
+        if structural_hash:
+            self._seen_circuit_hashes.add(structural_hash)
 
         # Determine logging behavior
-        should_log = self._should_log(exec_count, circuit_hash, is_new_circuit)
+        should_log = self._should_log(exec_count, structural_hash, is_new_circuit)
 
         # Build execution options
         options: dict[str, Any] = {}
@@ -513,17 +522,18 @@ class TrackedDevice:
                 shots=shots,
                 task_ids=task_ids,
                 submitted_at=submitted_at,
-                circuit_hash=circuit_hash,
+                structural_hash=structural_hash,
+                parametric_hash=parametric_hash,
                 execution_index=exec_count,
                 options=options if options else None,
             )
 
-            if circuit_hash:
-                self._logged_circuit_hashes.add(circuit_hash)
+            if structural_hash:
+                self._logged_circuit_hashes.add(structural_hash)
 
             self._logged_execution_count += 1
 
-            # Set tracker tags/params (P1 fix: provider is platform, not SDK)
+            # Set tracker tags/params
             self.tracker.set_tag("backend_name", device_name)
             self.tracker.set_tag("provider", "aws_braket")
             self.tracker.set_tag("adapter", "devqubit-braket")
@@ -545,7 +555,8 @@ class TrackedDevice:
                 "sdk": "braket",
                 "num_circuits": len(circuits_for_logging),
                 "execution_count": exec_count,
-                "program_hash": circuit_hash,
+                "structural_hash": structural_hash,
+                "parametric_hash": parametric_hash,
                 "shots": shots,
                 "task_ids": task_ids,
             }
@@ -607,14 +618,21 @@ class TrackedDevice:
         self._execution_count += 1
         exec_count = self._execution_count
 
-        # Compute circuit hash
-        circuit_hash = _compute_structural_hash(circuits_for_logging)
-        is_new_circuit = circuit_hash and circuit_hash not in self._seen_circuit_hashes
-        if circuit_hash:
-            self._seen_circuit_hashes.add(circuit_hash)
+        # Compute hashes
+        structural_hash = _compute_structural_hash(circuits_for_logging)
+
+        # Extract inputs for parametric hash (Braket's FreeParameter bindings)
+        inputs = kwargs.get("inputs")
+        parametric_hash = _compute_parametric_hash(circuits_for_logging, inputs)
+
+        is_new_circuit = (
+            structural_hash and structural_hash not in self._seen_circuit_hashes
+        )
+        if structural_hash:
+            self._seen_circuit_hashes.add(structural_hash)
 
         # Determine logging behavior
-        should_log = self._should_log(exec_count, circuit_hash, is_new_circuit)
+        should_log = self._should_log(exec_count, structural_hash, is_new_circuit)
 
         # Build execution options
         options: dict[str, Any] = {
@@ -657,17 +675,18 @@ class TrackedDevice:
                 shots=shots,
                 task_ids=[],  # Batch doesn't have a single ID upfront
                 submitted_at=submitted_at,
-                circuit_hash=circuit_hash,
+                structural_hash=structural_hash,
+                parametric_hash=parametric_hash,
                 execution_index=exec_count,
                 options=options,
             )
 
-            if circuit_hash:
-                self._logged_circuit_hashes.add(circuit_hash)
+            if structural_hash:
+                self._logged_circuit_hashes.add(structural_hash)
 
             self._logged_execution_count += 1
 
-            # Set tracker tags/params (P1 fix: provider is platform, not SDK)
+            # Set tracker tags/params
             self.tracker.set_tag("backend_name", device_name)
             self.tracker.set_tag("provider", "aws_braket")
             self.tracker.set_tag("adapter", "devqubit-braket")
@@ -691,7 +710,8 @@ class TrackedDevice:
                 "sdk": "braket",
                 "num_circuits": len(circuits_for_logging),
                 "execution_count": exec_count,
-                "program_hash": circuit_hash,
+                "structural_hash": structural_hash,
+                "parametric_hash": parametric_hash,
                 "shots": shots,
                 "batch": True,
             }
@@ -717,7 +737,7 @@ class TrackedDevice:
     def _should_log(
         self,
         exec_count: int,
-        circuit_hash: str | None,
+        structural_hash: str | None,
         is_new_circuit: bool,
     ) -> bool:
         """Determine if this execution should be logged."""

--- a/packages/devqubit-braket/tests/test_braket_adapter.py
+++ b/packages/devqubit-braket/tests/test_braket_adapter.py
@@ -12,7 +12,7 @@ from devqubit_braket.adapter import (
     BraketAdapter,
     TrackedDevice,
     TrackedTaskBatch,
-    _compute_circuit_hash,
+    _compute_structural_hash,
     _is_program_set,
     _materialize_task_spec,
 )
@@ -228,7 +228,7 @@ class TestCircuitHash:
         c1 = Circuit().h(0).cnot(0, 1).measure([0, 1])
         c2 = Circuit().h(0).cnot(0, 1).measure([0, 1])
 
-        assert _compute_circuit_hash([c1]) == _compute_circuit_hash([c2])
+        assert _compute_structural_hash([c1]) == _compute_structural_hash([c2])
 
     def test_gate_or_target_changes_hash(self):
         """Different gates or targets produce different hashes."""
@@ -236,17 +236,17 @@ class TestCircuitHash:
         b = Circuit().h(1).measure(1)
         c = Circuit().x(0).measure(0)
 
-        assert _compute_circuit_hash([a]) != _compute_circuit_hash([b])
-        assert _compute_circuit_hash([a]) != _compute_circuit_hash([c])
+        assert _compute_structural_hash([a]) != _compute_structural_hash([b])
+        assert _compute_structural_hash([a]) != _compute_structural_hash([c])
 
     def test_empty_circuits_returns_none(self):
         """Empty circuit list returns None."""
-        assert _compute_circuit_hash([]) is None
+        assert _compute_structural_hash([]) is None
 
     def test_hash_format(self):
         """Hash has correct sha256 prefix format."""
         c = Circuit().h(0)
-        h = _compute_circuit_hash([c])
+        h = _compute_structural_hash([c])
 
         assert h is not None
         assert h.startswith("sha256:")

--- a/packages/devqubit-cirq/tests/test_cirq_adapter.py
+++ b/packages/devqubit-cirq/tests/test_cirq_adapter.py
@@ -12,7 +12,7 @@ import pytest
 import sympy
 from devqubit_cirq.adapter import (
     CirqAdapter,
-    _compute_circuit_hash,
+    _compute_structural_hash,
     _materialize_circuits,
 )
 from devqubit_engine.core.run import track
@@ -413,8 +413,8 @@ class TestCircuitHash:
     def test_deterministic_and_parameter_invariant(self, parameterized_circuit):
         """Hash is deterministic and parameter-invariant."""
         circuits, _ = _materialize_circuits(parameterized_circuit)
-        h1 = _compute_circuit_hash(circuits)
-        h2 = _compute_circuit_hash(circuits)
+        h1 = _compute_structural_hash(circuits)
+        h2 = _compute_structural_hash(circuits)
         assert h1 == h2
         assert isinstance(h1, str) and h1.startswith("sha256:")
 
@@ -424,7 +424,7 @@ class TestCircuitHash:
         b = sympy.Symbol("b")
         c1 = cirq.Circuit(cirq.rx(a)(q0), cirq.measure(q0, key="m"))
         c2 = cirq.Circuit(cirq.rx(b)(q0), cirq.measure(q0, key="m"))
-        assert _compute_circuit_hash([c1]) == _compute_circuit_hash([c2])
+        assert _compute_structural_hash([c1]) == _compute_structural_hash([c2])
 
     @pytest.mark.parametrize(
         "variant_builder",
@@ -460,7 +460,7 @@ class TestCircuitHash:
         )
         variant = variant_builder(q0, q1)
 
-        assert _compute_circuit_hash([base]) != _compute_circuit_hash([variant])
+        assert _compute_structural_hash([base]) != _compute_structural_hash([variant])
 
 
 class TestBackendTypeCompliance:

--- a/packages/devqubit-engine/src/devqubit_engine/artifacts.py
+++ b/packages/devqubit-engine/src/devqubit_engine/artifacts.py
@@ -97,7 +97,7 @@ def load_json_artifact(
 
 
 def get_artifact_digests(
-    record: RunRecord | dict[str, Any],
+    record: RunRecord,
     role: str,
     *,
     kind_contains: str | None = None,
@@ -107,9 +107,8 @@ def get_artifact_digests(
 
     Parameters
     ----------
-    record : RunRecord or dict
-        Run record containing artifacts. Accepts dict for
-        backward compatibility with raw record dictionaries.
+    record : RunRecord
+        Run record containing artifacts.
     role : str
         Filter by artifact role (e.g., "program", "results").
     kind_contains : str, optional
@@ -120,20 +119,8 @@ def get_artifact_digests(
     list of str
         Sorted list of artifact digests matching filters.
     """
-    # Handle both RunRecord and dict for backward compatibility
-    if isinstance(record, RunRecord):
-        artifacts = record.artifacts
-    else:
-        artifacts = []
-        for artifact_dict in record.get("artifacts", []) or []:
-            if isinstance(artifact_dict, dict):
-                try:
-                    artifacts.append(ArtifactRef.from_dict(artifact_dict))
-                except (KeyError, ValueError):
-                    continue
-
     digests: list[str] = []
-    for artifact in artifacts:
+    for artifact in record.artifacts:
         if artifact.role != role:
             continue
 

--- a/packages/devqubit-engine/src/devqubit_engine/circuit/extractors.py
+++ b/packages/devqubit-engine/src/devqubit_engine/circuit/extractors.py
@@ -13,11 +13,16 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import TYPE_CHECKING
 
 from devqubit_engine.circuit.models import SDK, CircuitData, CircuitFormat
 from devqubit_engine.core.record import RunRecord
 from devqubit_engine.storage.protocols import ObjectStoreProtocol
 from devqubit_engine.uec.types import ArtifactRef
+
+
+if TYPE_CHECKING:
+    from devqubit_engine.uec.envelope import ExecutionEnvelope
 
 
 logger = logging.getLogger(__name__)
@@ -244,3 +249,176 @@ def extract_openqasm_source(
                 continue
 
     return None
+
+
+def extract_circuit_from_refs(
+    refs: list[ArtifactRef],
+    store: ObjectStoreProtocol,
+    *,
+    prefer_formats: list[str] | None = None,
+) -> CircuitData | None:
+    """
+    Extract circuit data from artifact references.
+
+    Uses UEC program artifact references to load circuit data,
+    ensuring we get exactly the circuit referenced by the envelope.
+
+    Parameters
+    ----------
+    refs : list of ArtifactRef
+        Artifact references from envelope.program.logical or .physical.
+    store : ObjectStoreProtocol
+        Object store to load artifact data from.
+    prefer_formats : list of str, optional
+        Preferred format order (e.g., ["openqasm3", "qpy"]).
+        Defaults to OpenQASM3 first.
+
+    Returns
+    -------
+    CircuitData or None
+        Extracted circuit data, or None if not found.
+
+    Notes
+    -----
+    This is the UEC-aware extraction function. Use this when you have
+    an envelope with program artifact refs.
+    """
+    if not refs:
+        return None
+
+    if prefer_formats is None:
+        prefer_formats = ["openqasm3", "openqasm", "qasm", "qpy", "jaqcd", "cirq"]
+
+    # Build lookup by format pattern
+    ref_by_kind: dict[str, ArtifactRef] = {}
+    for ref in refs:
+        kind_lower = ref.kind.lower()
+        ref_by_kind[kind_lower] = ref
+
+    # Try preferred formats in order
+    for fmt_pattern in prefer_formats:
+        for kind_lower, ref in ref_by_kind.items():
+            if fmt_pattern in kind_lower:
+                try:
+                    data = store.get_bytes(ref.digest)
+
+                    # Determine format
+                    if "qpy" in kind_lower:
+                        return CircuitData(
+                            data=data, format=CircuitFormat.QPY, sdk=SDK.QISKIT
+                        )
+                    elif "openqasm3" in kind_lower or "qasm3" in kind_lower:
+                        return CircuitData(
+                            data=data.decode("utf-8"),
+                            format=CircuitFormat.OPENQASM3,
+                            sdk=SDK.UNKNOWN,
+                        )
+                    elif "openqasm" in kind_lower or "qasm" in kind_lower:
+                        text = data.decode("utf-8")
+                        fmt = CircuitFormat.OPENQASM3
+                        if re.match(r"^\s*OPENQASM\s+2\.", text):
+                            fmt = CircuitFormat.OPENQASM2
+                        return CircuitData(data=text, format=fmt, sdk=SDK.UNKNOWN)
+                    elif "jaqcd" in kind_lower:
+                        return CircuitData(
+                            data=data.decode("utf-8"),
+                            format=CircuitFormat.JAQCD,
+                            sdk=SDK.BRAKET,
+                        )
+                    elif "cirq" in kind_lower:
+                        return CircuitData(
+                            data=data.decode("utf-8"),
+                            format=CircuitFormat.CIRQ_JSON,
+                            sdk=SDK.CIRQ,
+                        )
+                    else:
+                        # Generic - try as text
+                        return CircuitData(
+                            data=data.decode("utf-8"),
+                            format=CircuitFormat.OPENQASM3,
+                            sdk=SDK.UNKNOWN,
+                        )
+                except Exception as e:
+                    logger.debug("Failed to load artifact %s: %s", ref.digest[:24], e)
+                    continue
+
+    # Fallback: try first available ref
+    if refs:
+        ref = refs[0]
+        try:
+            data = store.get_bytes(ref.digest)
+            # Try as text first
+            try:
+                text = data.decode("utf-8")
+                return CircuitData(
+                    data=text, format=CircuitFormat.OPENQASM3, sdk=SDK.UNKNOWN
+                )
+            except UnicodeDecodeError:
+                # Binary format
+                return CircuitData(data=data, format=CircuitFormat.QPY, sdk=SDK.QISKIT)
+        except Exception as e:
+            logger.debug("Failed to load fallback artifact: %s", e)
+
+    return None
+
+
+def extract_circuit_from_envelope(
+    envelope: "ExecutionEnvelope",
+    store: ObjectStoreProtocol,
+    *,
+    which: str = "logical",
+    prefer_formats: list[str] | None = None,
+) -> CircuitData | None:
+    """
+    Extract circuit data from ExecutionEnvelope.
+
+    This is the primary UEC-aware circuit extraction function. Use this
+    when you have an envelope and need to extract circuit data.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Envelope containing program snapshot.
+    store : ObjectStoreProtocol
+        Object store to load artifact data from.
+    which : str, default="logical"
+        Which circuit to extract: "logical" (pre-transpilation) or
+        "physical" (post-transpilation/executed).
+    prefer_formats : list of str, optional
+        Preferred format order.
+
+    Returns
+    -------
+    CircuitData or None
+        Extracted circuit data, or None if not found.
+
+    Examples
+    --------
+    >>> from devqubit_engine.uec.resolver import resolve_envelope
+    >>> from devqubit_engine.circuit.extractors import extract_circuit_from_envelope
+    >>>
+    >>> envelope = resolve_envelope(record, store)
+    >>> circuit = extract_circuit_from_envelope(envelope, store, which="logical")
+    """
+    # Avoid circular import
+
+    if not envelope.program:
+        logger.debug("No program snapshot in envelope")
+        return None
+
+    # Get refs for requested circuit type
+    if which == "logical":
+        artifacts = envelope.program.logical
+    elif which == "physical":
+        artifacts = envelope.program.physical
+    else:
+        raise ValueError(f"which must be 'logical' or 'physical', got '{which}'")
+
+    if not artifacts:
+        logger.debug("No %s artifacts in program snapshot", which)
+        return None
+
+    # Extract refs from ProgramArtifact wrappers
+    refs = [a.ref for a in artifacts if a.ref]
+
+    return extract_circuit_from_refs(refs, store, prefer_formats=prefer_formats)

--- a/packages/devqubit-engine/src/devqubit_engine/circuit/hashing.py
+++ b/packages/devqubit-engine/src/devqubit_engine/circuit/hashing.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 devqubit
+
+"""
+Circuit hashing utilities.
+
+This module provides canonical hashing functions for quantum circuits.
+All adapters should use these functions to ensure consistent hash computation
+across different SDKs.
+
+Hash Types
+----------
+- **structural_hash**: Hash of circuit structure (gates, qubits, controls).
+  Ignores parameter values. Same hash means same circuit template.
+
+- **parametric_hash**: Hash of structure + bound parameter values.
+  Same hash means identical circuit for this specific execution.
+
+Usage
+-----
+Adapters map their SDK-specific circuit representations to a canonical
+operation stream, then use these functions:
+
+>>> from devqubit_engine.circuit.hashing import hash_structural, hash_parametric
+>>>
+>>> ops = [
+...     {"gate": "h", "qubits": [0]},
+...     {"gate": "cx", "qubits": [0, 1]},
+...     {"gate": "rz", "qubits": [0], "params": ["theta"]},
+... ]
+>>> structural = hash_structural(ops)
+>>>
+>>> bound_params = {"theta": 1.5707963267948966}
+>>> parametric = hash_parametric(ops, bound_params)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from devqubit_engine.utils.serialization import to_jsonable
+
+
+def _normalize_float(value: float, precision: int = 10) -> str:
+    """
+    Normalize float to deterministic string representation.
+
+    Parameters
+    ----------
+    value : float
+        Float value to normalize.
+    precision : int, default=10
+        Number of significant digits.
+
+    Returns
+    -------
+    str
+        Normalized string representation.
+    """
+    if value == 0.0:
+        return "0"
+    if abs(value) < 1e-15:
+        return "0"
+    return f"{value:.{precision}g}"
+
+
+def _normalize_operation(
+    op: dict[str, Any],
+    include_params: bool = False,
+) -> dict:
+    """
+    Normalize an operation dict for hashing.
+
+    Parameters
+    ----------
+    op : dict
+        Operation dictionary with keys like 'gate', 'qubits', 'params', 'controls'.
+    include_params : bool, default=False
+        If True, include parameter values. If False, only include param names.
+
+    Returns
+    -------
+    dict
+        Normalized operation suitable for hashing.
+    """
+    normalized: dict[str, Any] = {
+        "gate": str(op.get("gate", "unknown")).lower(),
+        "qubits": sorted(int(q) for q in op.get("qubits", [])),
+    }
+
+    # Controls (for controlled gates)
+    if op.get("controls"):
+        normalized["controls"] = sorted(int(c) for c in op["controls"])
+
+    # Classical bits (for measurements)
+    if op.get("clbits"):
+        normalized["clbits"] = sorted(int(c) for c in op["clbits"])
+
+    # Parameters - structural hash only includes names, parametric includes values
+    if op.get("params"):
+        params = op["params"]
+        if include_params:
+            # Include actual values (for parametric hash)
+            if isinstance(params, dict):
+                normalized["params"] = {
+                    str(k): (
+                        _normalize_float(float(v))
+                        if isinstance(v, (int, float))
+                        else str(v)
+                    )
+                    for k, v in sorted(params.items())
+                }
+            elif isinstance(params, (list, tuple)):
+                normalized["params"] = [
+                    (
+                        _normalize_float(float(v))
+                        if isinstance(v, (int, float))
+                        else str(v)
+                    )
+                    for v in params
+                ]
+        else:
+            # Only param names/positions (for structural hash)
+            if isinstance(params, dict):
+                normalized["param_names"] = sorted(str(k) for k in params.keys())
+            elif isinstance(params, (list, tuple)):
+                normalized["param_count"] = len(params)
+
+    # Condition (for conditional gates)
+    if op.get("condition"):
+        normalized["condition"] = to_jsonable(op["condition"])
+
+    return normalized
+
+
+def hash_structural(op_stream: list[dict[str, Any]]) -> str:
+    """
+    Compute structural hash of circuit operation stream.
+
+    The structural hash captures the circuit template - gate types, qubit
+    connectivity, and parameter placeholders - but NOT parameter values.
+    Two circuits with the same structure but different parameter values
+    will have the same structural hash.
+
+    Parameters
+    ----------
+    op_stream : list of dict
+        List of operation dictionaries. Each operation should have:
+        - gate: Gate name (str)
+        - qubits: List of qubit indices
+        - params: Optional parameter names or values
+        - controls: Optional control qubit indices
+        - clbits: Optional classical bit indices
+
+    Returns
+    -------
+    str
+        SHA-256 hash of normalized circuit structure.
+
+    Examples
+    --------
+    >>> ops = [
+    ...     {"gate": "h", "qubits": [0]},
+    ...     {"gate": "cx", "qubits": [0, 1]},
+    ...     {"gate": "rz", "qubits": [0], "params": {"theta": 0.5}},
+    ... ]
+    >>> hash_structural(ops)
+    'sha256:abc123...'
+
+    Notes
+    -----
+    Adapters should convert their SDK-specific circuit representations
+    to this canonical operation stream format before hashing.
+    """
+    normalized_ops = [
+        _normalize_operation(op, include_params=False) for op in op_stream
+    ]
+
+    # Create deterministic JSON representation
+    canonical = json.dumps(
+        {"version": "1.0", "ops": normalized_ops},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def hash_parametric(
+    op_stream: list[dict[str, Any]],
+    bound_params: dict[str, Any] | None = None,
+) -> str:
+    """
+    Compute parametric hash of circuit with bound parameters.
+
+    The parametric hash captures both the circuit structure AND the bound
+    parameter values. Two circuits with the same structure but different
+    parameter values will have different parametric hashes.
+
+    Parameters
+    ----------
+    op_stream : list of dict
+        List of operation dictionaries (same format as hash_structural).
+    bound_params : dict, optional
+        Dictionary mapping parameter names to values. If provided, these
+        values are merged with inline param values from op_stream.
+
+    Returns
+    -------
+    str
+        SHA-256 hash of normalized circuit with bound parameters.
+
+    Examples
+    --------
+    >>> ops = [
+    ...     {"gate": "h", "qubits": [0]},
+    ...     {"gate": "rz", "qubits": [0], "params": {"theta": None}},
+    ... ]
+    >>> bound = {"theta": 1.5707963267948966}
+    >>> hash_parametric(ops, bound)
+    'sha256:def456...'
+
+    Notes
+    -----
+    If circuit has no parameters, ``parametric_hash == structural_hash``.
+    This is the expected behavior per UEC spec.
+    """
+    bound_params = bound_params or {}
+
+    # Apply bound params to operations
+    resolved_ops: list[dict[str, Any]] = []
+    for op in op_stream:
+        resolved_op = dict(op)
+        if op.get("params"):
+            params = op["params"]
+            if isinstance(params, dict):
+                # Merge bound params
+                resolved_params = {}
+                for k, v in params.items():
+                    if v is None and k in bound_params:
+                        resolved_params[k] = bound_params[k]
+                    else:
+                        resolved_params[k] = v
+                resolved_op["params"] = resolved_params
+        resolved_ops.append(resolved_op)
+
+    normalized_ops = [
+        _normalize_operation(op, include_params=True) for op in resolved_ops
+    ]
+
+    # Create deterministic JSON representation
+    canonical = json.dumps(
+        {"version": "1.0", "ops": normalized_ops, "bound": to_jsonable(bound_params)},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def hash_circuit_pair(
+    op_stream: list[dict[str, Any]],
+    bound_params: dict[str, Any] | None = None,
+) -> tuple[str, str]:
+    """
+    Compute both structural and parametric hashes in one call.
+
+    Convenience function for adapters that need both hashes.
+
+    Parameters
+    ----------
+    op_stream : list of dict
+        List of operation dictionaries.
+    bound_params : dict, optional
+        Bound parameter values.
+
+    Returns
+    -------
+    tuple of (str, str)
+        (structural_hash, parametric_hash)
+
+    Examples
+    --------
+    >>> ops = [{"gate": "rx", "qubits": [0], "params": {"theta": 0.5}}]
+    >>> struct, param = hash_circuit_pair(ops)
+    """
+    structural = hash_structural(op_stream)
+    parametric = hash_parametric(op_stream, bound_params)
+    return structural, parametric

--- a/packages/devqubit-engine/src/devqubit_engine/compare/diff.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/diff.py
@@ -48,7 +48,6 @@ from devqubit_engine.uec.calibration import DeviceCalibration
 from devqubit_engine.uec.device import DeviceSnapshot
 from devqubit_engine.uec.envelope import ExecutionEnvelope
 from devqubit_engine.uec.resolver import (
-    get_program_hash_from_envelope,
     resolve_envelope,
 )
 from devqubit_engine.uec.result import canonicalize_bitstrings
@@ -189,8 +188,8 @@ def _extract_counts(
     Extract counts from envelope or Run artifacts.
 
     Uses UEC-first strategy: extracts counts from ExecutionEnvelope,
-    falling back to Run counts artifact if envelope has no counts.
-    Always canonicalizes bitstrings to cbit0_right format for comparison.
+    falling back to Run counts artifact only for synthesized (manual)
+    envelopes. For adapter envelopes, missing counts is reported as None.
 
     Parameters
     ----------
@@ -210,7 +209,7 @@ def _extract_counts(
     """
     # Use provided envelope or resolve
     if envelope is None:
-        envelope = resolve_envelope(record, store, strict=False)
+        envelope = resolve_envelope(record, store)
 
     # Try to get counts from envelope (UEC-first)
     if envelope.result.items:
@@ -231,7 +230,18 @@ def _extract_counts(
                 else:
                     return {str(k): int(v) for k, v in raw_counts.items()}
 
-    # Fallback: Run counts artifact
+    # Fallback: Run counts artifact - ONLY for synthesized (manual) envelopes
+    is_synthesized = envelope.metadata.get("synthesized_from_run", False)
+
+    if not is_synthesized:
+        # Adapter envelope without counts - this is an integration issue
+        logger.debug(
+            "Adapter envelope for run %s has no counts in result items",
+            record.run_id,
+        )
+        return None
+
+    # Manual/synthesized envelope - fallback to Run artifact is allowed
     counts_info = get_counts(record, store)
     if counts_info is None:
         return None
@@ -255,7 +265,8 @@ def _load_device_snapshot(
     Load device snapshot from envelope or run record.
 
     Uses UEC-first strategy: extracts device from ExecutionEnvelope,
-    falling back to Run record metadata if envelope has no device.
+    falling back to Run record metadata only for synthesized (manual)
+    envelopes.
 
     Parameters
     ----------
@@ -270,6 +281,12 @@ def _load_device_snapshot(
     -------
     DeviceSnapshot or None
         Device snapshot if available, None otherwise.
+
+    Notes
+    -----
+    Fallback to Run record metadata is only allowed for synthesized
+    (manual) envelopes. For adapter envelopes, if device is not present
+    in the envelope, None is returned.
     """
     # Use provided envelope or resolve
     if envelope is None:
@@ -279,7 +296,18 @@ def _load_device_snapshot(
     if envelope.device is not None:
         return envelope.device
 
-    # Fallback: construct from record metadata (Run compatibility)
+    # Fallback: construct from record metadata - ONLY for synthesized envelopes
+    is_synthesized = envelope.metadata.get("synthesized_from_run", False)
+
+    if not is_synthesized:
+        # Adapter envelope without device - this may be intentional (no device info)
+        logger.debug(
+            "Adapter envelope for run %s has no device snapshot",
+            record.run_id,
+        )
+        return None
+
+    # Manual/synthesized envelope - fallback to Run record is allowed
     backend = record.record.get("backend") or {}
     if not isinstance(backend, dict):
         return None
@@ -321,8 +349,8 @@ def _extract_circuit_summary(
     """
     Extract circuit summary from envelope or run record.
 
-    Uses UEC-first strategy: extracts circuit from envelope refs,
-    falling back to run record artifacts if envelope not available.
+    Uses UEC-first strategy: extracts circuit from envelope refs, falling
+    back to run record artifacts only for synthesized (manual) envelopes.
 
     Parameters
     ----------
@@ -348,61 +376,28 @@ def _extract_circuit_summary(
     if envelope is not None:
         circuit_data = extract_circuit_from_envelope(envelope, store, which=which)
 
-    # Fallback to legacy extraction
+    # Fallback to Run artifacts - ONLY for synthesized (manual) envelopes
     if circuit_data is None:
-        circuit_data = extract_circuit(record, store)
+        is_synthesized = envelope is not None and envelope.metadata.get(
+            "synthesized_from_run", False
+        )
+
+        if is_synthesized:
+            # Manual envelope - fallback is allowed
+            circuit_data = extract_circuit(record, store)
+        elif envelope is not None:
+            # Adapter envelope without circuit refs - log and return None
+            logger.debug(
+                "Adapter envelope for run %s has no circuit refs for '%s'",
+                record.run_id,
+                which,
+            )
 
     if circuit_data is not None:
         try:
             return summarize_circuit_data(circuit_data)
         except Exception as e:
             logger.debug("Failed to summarize circuit: %s", e)
-
-    return None
-
-
-def _extract_circuit_hash(
-    record: RunRecord,
-    envelope: ExecutionEnvelope | None = None,
-) -> str | None:
-    """
-    Extract structural hash from envelope or run record.
-
-    Uses UEC-first strategy: extracts structural_hash from envelope,
-    falling back to Run metadata if not in envelope.
-
-    The structural_hash ignores parameter values, making it suitable for
-    comparing parameterized circuits that were executed with different
-    parameter values.
-
-    Parameters
-    ----------
-    record : RunRecord
-        Run record to extract from.
-    envelope : ExecutionEnvelope, optional
-        Pre-resolved envelope.
-
-    Returns
-    -------
-    str or None
-        Structural hash if available.
-    """
-    # Try envelope first (UEC-first)
-    if envelope is not None:
-        program_hash = get_program_hash_from_envelope(envelope)
-        if program_hash:
-            return program_hash
-
-    # Fallback: try execute metadata (legacy circuit_hash field)
-    execute = record.record.get("execute", {})
-    if isinstance(execute, dict) and execute.get("circuit_hash"):
-        return str(execute["circuit_hash"])
-
-    # Fallback: try artifacts metadata
-    for artifact in record.artifacts:
-        meta = artifact.meta or {}
-        if meta.get("circuit_hash"):
-            return str(meta["circuit_hash"])
 
     return None
 
@@ -569,9 +564,9 @@ def diff_runs(
 
     logger.info("Comparing runs: %s vs %s", run_a.run_id, run_b.run_id)
 
-    # Resolve envelopes (UEC-first strategy, non-strict for backward compat)
-    envelope_a = resolve_envelope(run_a, store_a, strict=False)
-    envelope_b = resolve_envelope(run_b, store_b, strict=False)
+    # Resolve envelopes (UEC-first strategy, strict for adapters)
+    envelope_a = resolve_envelope(run_a, store_a)
+    envelope_b = resolve_envelope(run_b, store_b)
 
     result = ComparisonResult(
         run_id_a=run_a.run_id,

--- a/packages/devqubit-engine/src/devqubit_engine/compare/diff.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/diff.py
@@ -437,18 +437,16 @@ def _compare_programs(
         Detailed comparison with status, exact_match, structural_match,
         parametric_match, and hash availability.
     """
-    digests_a = get_artifact_digests(run_a, role="program")
-    digests_b = get_artifact_digests(run_b, role="program")
-
-    # Exact match: prefer envelope refs if available, else use all role=program
-    # This ensures we compare only the program artifacts referenced by envelope,
-    # not auxiliary artifacts like diagrams
+    # Exact match: prefer envelope refs if available (ignores auxiliary artifacts
+    # like diagrams), else fall back to all role=program artifacts
     if envelope_a and envelope_a.program:
         logical_digests_a = [a.ref.digest for a in envelope_a.program.logical if a.ref]
         physical_digests_a = [
             a.ref.digest for a in envelope_a.program.physical if a.ref
         ]
         digests_a = sorted(set(logical_digests_a + physical_digests_a))
+    else:
+        digests_a = get_artifact_digests(run_a, role="program")
 
     if envelope_b and envelope_b.program:
         logical_digests_b = [a.ref.digest for a in envelope_b.program.logical if a.ref]
@@ -456,6 +454,8 @@ def _compare_programs(
             a.ref.digest for a in envelope_b.program.physical if a.ref
         ]
         digests_b = sorted(set(logical_digests_b + physical_digests_b))
+    else:
+        digests_b = get_artifact_digests(run_b, role="program")
 
     exact_match = digests_a == digests_b
 

--- a/packages/devqubit-engine/src/devqubit_engine/compare/results.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/results.py
@@ -269,7 +269,7 @@ class ProgramMatchStatus(str, Enum):
     """
     Detailed program match status.
 
-    Based on structural (program_hash) and parametric (parametric_hash) comparison.
+    Based on structural (structural_hash) and parametric (parametric_hash) comparison.
 
     Attributes
     ----------
@@ -294,7 +294,7 @@ class ProgramComparison:
     """
     Detailed program comparison result.
 
-    Captures exact (digest), structural (program_hash), and parametric
+    Captures exact (digest), structural (structural_hash), and parametric
     (parametric_hash) matching to support different verification policies.
 
     Attributes
@@ -302,7 +302,7 @@ class ProgramComparison:
     exact_match : bool
         True if artifact digests are identical (byte-for-byte match).
     structural_match : bool
-        True if program_hash values match (same structure).
+        True if structural_hash values match (same structure).
     parametric_match : bool
         True if parametric_hash values match (same structure AND params).
     digests_a : list of str
@@ -310,9 +310,9 @@ class ProgramComparison:
     digests_b : list of str
         Program artifact digests from candidate.
     circuit_hash_a : str or None
-        Structural hash (program_hash) from baseline.
+        Structural hash (structural_hash) from baseline.
     circuit_hash_b : str or None
-        Structural hash (program_hash) from candidate.
+        Structural hash (structural_hash) from candidate.
     parametric_hash_a : str or None
         Parametric hash from baseline.
     parametric_hash_b : str or None
@@ -323,7 +323,7 @@ class ProgramComparison:
     Notes
     -----
     Hash semantics:
-    - ``program_hash``: Structure only. Same = same circuit template.
+    - ``structural_hash``: Structure only. Same = same circuit template.
     - ``parametric_hash``: Structure + params. Same = identical execution.
 
     For manual runs, hashes are unavailable and ``hash_available=False``.

--- a/packages/devqubit-engine/src/devqubit_engine/schema/devqubit.envelope.1.0.schema.json
+++ b/packages/devqubit-engine/src/devqubit_engine/schema/devqubit.envelope.1.0.schema.json
@@ -47,6 +47,29 @@
       "description": "Additional metadata (extensible)"
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "producer": {
+            "properties": {
+              "adapter": {
+                "not": { "const": "manual" }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "program": {
+            "required": ["structural_hash", "parametric_hash"]
+          }
+        },
+        "required": ["program", "execution"]
+      }
+    }
+  ],
   "$defs": {
     "producer_info": {
       "type": "object",
@@ -66,7 +89,7 @@
         },
         "adapter": {
           "type": "string",
-          "description": "Adapter package name (devqubit-qiskit, devqubit-braket, etc.)"
+          "description": "Adapter package name (devqubit-qiskit, devqubit-braket, etc.) or 'manual'"
         },
         "adapter_version": {
           "type": "string"
@@ -116,16 +139,31 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/program_artifact"
-          }
+          },
+          "description": "Logical (pre-transpilation) circuit artifacts"
         },
         "physical": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/program_artifact"
-          }
+          },
+          "description": "Physical (post-transpilation) circuit artifacts"
         },
-        "program_hash": {
-          "type": "string"
+        "structural_hash": {
+          "type": "string",
+          "description": "Hash of circuit structure (gates, qubits) ignoring parameter values"
+        },
+        "parametric_hash": {
+          "type": "string",
+          "description": "Hash of structure + bound parameter values"
+        },
+        "executed_structural_hash": {
+          "type": "string",
+          "description": "Structural hash of executed (physical) circuits"
+        },
+        "executed_parametric_hash": {
+          "type": "string",
+          "description": "Parametric hash of executed (physical) circuits"
         },
         "num_circuits": {
           "type": "integer",
@@ -362,10 +400,12 @@
     },
     "counts_format": {
       "type": "object",
-      "description": "Metadata about how counts are formatted",
+      "description": "Metadata about how counts are formatted - all fields required for production",
       "required": [
         "source_sdk",
-        "bit_order"
+        "source_key_format",
+        "bit_order",
+        "transformed"
       ],
       "properties": {
         "source_sdk": {
@@ -374,7 +414,7 @@
         },
         "source_key_format": {
           "type": "string",
-          "description": "Original format identifier"
+          "description": "Original format identifier (e.g., 'qiskit_little_endian', 'braket_big_endian', 'unknown')"
         },
         "bit_order": {
           "type": "string",
@@ -386,7 +426,7 @@
         },
         "transformed": {
           "type": "boolean",
-          "description": "Whether adapter remapped keys"
+          "description": "Whether adapter remapped keys to canonical format"
         },
         "num_clbits": {
           "type": "integer",

--- a/packages/devqubit-engine/src/devqubit_engine/schema/devqubit.envelope.1.0.schema.json
+++ b/packages/devqubit-engine/src/devqubit_engine/schema/devqubit.envelope.1.0.schema.json
@@ -68,6 +68,29 @@
         },
         "required": ["program", "execution"]
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "program": {
+            "properties": {
+              "physical": {
+                "type": "array",
+                "minItems": 1
+              }
+            },
+            "required": ["physical"]
+          }
+        },
+        "required": ["program"]
+      },
+      "then": {
+        "properties": {
+          "program": {
+            "required": ["executed_structural_hash", "executed_parametric_hash"]
+          }
+        }
+      }
     }
   ],
   "$defs": {

--- a/packages/devqubit-engine/src/devqubit_engine/uec/envelope.py
+++ b/packages/devqubit-engine/src/devqubit_engine/uec/envelope.py
@@ -284,6 +284,18 @@ class ExecutionEnvelope:
                     "Adapter run missing parametric_hash - adapters must provide "
                     "parametric hash"
                 )
+            # If physical circuits present, executed_*hash required
+            if self.program.physical:
+                if not self.program.executed_structural_hash:
+                    warnings.append(
+                        "Adapter run with physical circuits missing "
+                        "executed_structural_hash"
+                    )
+                if not self.program.executed_parametric_hash:
+                    warnings.append(
+                        "Adapter run with physical circuits missing "
+                        "executed_parametric_hash"
+                    )
 
         return warnings
 

--- a/packages/devqubit-engine/src/devqubit_engine/uec/envelope.py
+++ b/packages/devqubit-engine/src/devqubit_engine/uec/envelope.py
@@ -274,9 +274,9 @@ class ExecutionEnvelope:
         )
 
         if is_adapter_run and self.program:
-            if not self.program.program_hash:
+            if not self.program.structural_hash:
                 warnings.append(
-                    "Adapter run missing program_hash - adapters must provide "
+                    "Adapter run missing structural_hash - adapters must provide "
                     "structural hash"
                 )
             if not self.program.parametric_hash:

--- a/packages/devqubit-engine/src/devqubit_engine/uec/program.py
+++ b/packages/devqubit-engine/src/devqubit_engine/uec/program.py
@@ -141,7 +141,7 @@ class ProgramSnapshot:
         Logical (pre-transpilation) circuit artifacts.
     physical : list of ProgramArtifact
         Physical (post-transpilation) circuit artifacts.
-    program_hash : str, optional
+    structural_hash : str, optional
         Structural hash of logical circuits. Deterministic hash of circuit
         structure (gate sequence, qubits, controls) that IGNORES parameter
         values. Used for "same circuit template?" comparison.
@@ -149,7 +149,7 @@ class ProgramSnapshot:
         Structural + parameters hash. Deterministic hash of structure PLUS
         bound parameter values for this execution. Changes when any parameter
         value changes. Used for "same circuit with same params?" comparison.
-    executed_hash : str, optional
+    executed_structural_hash : str, optional
         Structural hash of executed (physical) circuits after transpilation.
     executed_parametric_hash : str, optional
         Structural + parameters hash of executed circuits.
@@ -162,20 +162,22 @@ class ProgramSnapshot:
     -----
     Hash semantics (contract for adapters):
 
-    - ``program_hash``: Structural only. Same value means same circuit template,
+    - ``structural_hash``: Structure only. Same value means same circuit template,
       even if parameter values differ (e.g., VQE iterations).
     - ``parametric_hash``: Structure + bound params. Same value means identical
       circuit for this specific execution.
 
-    For adapter runs, ``program_hash`` and ``parametric_hash`` are REQUIRED.
+    For adapter runs, ``structural_hash`` and ``parametric_hash`` are REQUIRED.
     For manual runs, they are optional (compare will report "hash unavailable").
+
+    If circuit has no parameters: ``parametric_hash == structural_hash`` (still required).
     """
 
     logical: list[ProgramArtifact] = field(default_factory=list)
     physical: list[ProgramArtifact] = field(default_factory=list)
-    program_hash: str | None = None
+    structural_hash: str | None = None
     parametric_hash: str | None = None
-    executed_hash: str | None = None
+    executed_structural_hash: str | None = None
     executed_parametric_hash: str | None = None
     num_circuits: int | None = None
     transpilation: TranspilationInfo | None = None
@@ -188,12 +190,12 @@ class ProgramSnapshot:
             "logical": [a.to_dict() for a in self.logical],
             "physical": [a.to_dict() for a in self.physical],
         }
-        if self.program_hash:
-            d["program_hash"] = self.program_hash
+        if self.structural_hash:
+            d["structural_hash"] = self.structural_hash
         if self.parametric_hash:
             d["parametric_hash"] = self.parametric_hash
-        if self.executed_hash:
-            d["executed_hash"] = self.executed_hash
+        if self.executed_structural_hash:
+            d["executed_structural_hash"] = self.executed_structural_hash
         if self.executed_parametric_hash:
             d["executed_parametric_hash"] = self.executed_parametric_hash
         if self.num_circuits is not None:
@@ -221,9 +223,9 @@ class ProgramSnapshot:
         return cls(
             logical=logical,
             physical=physical,
-            program_hash=d.get("program_hash"),
+            structural_hash=d.get("structural_hash"),
             parametric_hash=d.get("parametric_hash"),
-            executed_hash=d.get("executed_hash"),
+            executed_structural_hash=d.get("executed_structural_hash"),
             executed_parametric_hash=d.get("executed_parametric_hash"),
             num_circuits=d.get("num_circuits"),
             transpilation=transpilation,

--- a/packages/devqubit-engine/src/devqubit_engine/uec/resolver.py
+++ b/packages/devqubit-engine/src/devqubit_engine/uec/resolver.py
@@ -470,6 +470,8 @@ def _build_result_from_run(
                         if isinstance(exp, dict) and exp.get("counts"):
                             counts_data = exp["counts"]
                             shots = sum(counts_data.values()) if counts_data else 0
+                            # NOTE: For manual runs, we assume cbit0_right format.
+                            # See detailed comment below in simple format case.
                             items.append(
                                 ResultItem(
                                     item_index=idx,
@@ -493,6 +495,12 @@ def _build_result_from_run(
                     counts_data = payload.get("counts", {})
                     if counts_data:
                         shots = sum(counts_data.values())
+                        # NOTE: For manual runs without adapter, we assume
+                        # cbit0_right (canonical) format. This is a best-effort
+                        # assumption since manual runs don't have SDK metadata.
+                        # Compare operations will use this assumption for
+                        # canonicalization - if the actual format differs,
+                        # TVD results may be incorrect.
                         items.append(
                             ResultItem(
                                 item_index=0,

--- a/packages/devqubit-engine/tests/conftest.py
+++ b/packages/devqubit-engine/tests/conftest.py
@@ -99,7 +99,7 @@ def run_factory() -> Callable[..., RunRecord]:
     def _make_run_record(
         run_id: str = "TEST123456",
         project: str = "test_project",
-        adapter: str = "test_adapter",
+        adapter: str = "manual",
         backend_name: str = "test_backend",
         backend_type: str = "simulator",
         provider: str = "test_provider",

--- a/packages/devqubit-pennylane/src/devqubit_pennylane/adapter.py
+++ b/packages/devqubit-pennylane/src/devqubit_pennylane/adapter.py
@@ -731,7 +731,7 @@ def patch_device(
                 }
                 self._devqubit_logged_execution_count += 1
 
-            # Build ProgramSnapshot (UEC v1.0 compliant)
+            # Build ProgramSnapshot
             # PennyLane doesn't transpile, so executed_*_hash == *_hash
             self._devqubit_program_snapshot = ProgramSnapshot(
                 logical=program_artifacts,
@@ -843,9 +843,9 @@ def patch_device(
                     "success": execution_succeeded,
                 }
 
-                # Create and finalize ExecutionEnvelope (UEC 1.0)
+                # Create and finalize ExecutionEnvelope
                 if self._devqubit_device_snapshot is not None:
-                    # Create ProducerInfo for UEC 1.0
+                    # Create ProducerInfo
                     sdk_versions = collect_sdk_versions()
                     producer = ProducerInfo.create(
                         adapter="devqubit-pennylane",

--- a/packages/devqubit-pennylane/src/devqubit_pennylane/results.py
+++ b/packages/devqubit-pennylane/src/devqubit_pennylane/results.py
@@ -409,7 +409,7 @@ def _extract_probabilities(
     Extract probabilities from PennyLane results as quasi-probability distributions.
 
     Handles both single circuit (1D array) and batch (list of arrays) cases.
-    Returns data suitable for QuasiProbability (UEC v1.0 compliant).
+    Returns data suitable for QuasiProbability.
 
     Parameters
     ----------
@@ -493,7 +493,7 @@ def build_result_snapshot(
     """
     Build a ResultSnapshot from PennyLane execution results.
 
-    Uses UEC 1.0 structure with items[] for per-circuit results.
+    Uses UEC structure with items[] for per-circuit results.
 
     Parameters
     ----------
@@ -515,7 +515,7 @@ def build_result_snapshot(
     Returns
     -------
     ResultSnapshot
-        Structured result snapshot following UEC 1.0.
+        Structured result snapshot.
     """
     # Determine status
     status = "completed" if success else "failed"
@@ -528,7 +528,7 @@ def build_result_snapshot(
             message=error_info.get("message", "Unknown error"),
         )
 
-    # Build items list (UEC 1.0)
+    # Build items list
     items: list[ResultItem] = []
 
     if success and results is not None:
@@ -572,7 +572,7 @@ def build_result_snapshot(
                         )
                     )
 
-            # Handle probabilities - use quasi_probability (UEC v1.0 compliant)
+            # Handle probabilities - use quasi_probability
             elif "probability" in rt_lower or "probs" in rt_lower:
                 probs_list = _extract_probabilities(results, num_circuits)
                 for pd in probs_list:

--- a/packages/devqubit-pennylane/src/devqubit_pennylane/results.py
+++ b/packages/devqubit-pennylane/src/devqubit_pennylane/results.py
@@ -18,6 +18,7 @@ import numpy as np
 from devqubit_engine.uec.result import (
     CountsFormat,
     NormalizedExpectation,
+    QuasiProbability,
     ResultError,
     ResultItem,
     ResultSnapshot,
@@ -392,14 +393,23 @@ def _extract_sample_counts(
     return counts_list
 
 
+@dataclass
+class _ProbabilityData:
+    """Internal representation for extracted probability distribution."""
+
+    circuit_index: int
+    distribution: dict[str, float]
+
+
 def _extract_probabilities(
     results: Any,
     num_circuits: int = 1,
-) -> list[_CountsData]:
+) -> list[_ProbabilityData]:
     """
-    Extract probabilities from PennyLane results as pseudo-counts.
+    Extract probabilities from PennyLane results as quasi-probability distributions.
 
     Handles both single circuit (1D array) and batch (list of arrays) cases.
+    Returns data suitable for QuasiProbability (UEC v1.0 compliant).
 
     Parameters
     ----------
@@ -410,13 +420,18 @@ def _extract_probabilities(
 
     Returns
     -------
-    list of _CountsData
-        Normalized probabilities as counts (values sum to ~1).
+    list of _ProbabilityData
+        Probability distributions with float values.
+
+    Notes
+    -----
+    PennyLane qml.probs() returns computational basis state probabilities.
+    Bitstring format is wire[0] as leftmost bit (cbit0_left in UEC terms).
     """
     if results is None:
         return []
 
-    counts_list: list[_CountsData] = []
+    prob_list: list[_ProbabilityData] = []
 
     try:
         arr = _to_numpy(results)
@@ -425,20 +440,19 @@ def _extract_probabilities(
         if num_circuits == 1 and arr is not None and arr.ndim == 1:
             probs = arr.tolist()
             num_bits = max(1, (len(probs) - 1).bit_length()) if probs else 0
-            counts_dict = {
+            distribution = {
                 format(j, f"0{num_bits}b"): float(p)
                 for j, p in enumerate(probs)
                 if p > 1e-10  # Filter near-zero probabilities
             }
-            if counts_dict:
-                counts_list.append(
-                    _CountsData(
+            if distribution:
+                prob_list.append(
+                    _ProbabilityData(
                         circuit_index=0,
-                        counts=counts_dict,
-                        shots=None,  # Probabilities don't have shots
+                        distribution=distribution,
                     )
                 )
-            return counts_list
+            return prob_list
 
         # Batch case: iterable of probability arrays
         if hasattr(results, "__iter__") and not isinstance(results, (str, dict)):
@@ -447,24 +461,23 @@ def _extract_probabilities(
                 if res_arr is not None and res_arr.ndim >= 1:
                     probs = res_arr.flatten().tolist()
                     num_bits = max(1, (len(probs) - 1).bit_length()) if probs else 0
-                    counts_dict = {
+                    distribution = {
                         format(j, f"0{num_bits}b"): float(p)
                         for j, p in enumerate(probs)
                         if p > 1e-10
                     }
-                    if counts_dict:
-                        counts_list.append(
-                            _CountsData(
+                    if distribution:
+                        prob_list.append(
+                            _ProbabilityData(
                                 circuit_index=i,
-                                counts=counts_dict,
-                                shots=None,
+                                distribution=distribution,
                             )
                         )
 
     except (TypeError, ValueError) as e:
         logger.debug("Failed to extract probabilities: %s", e)
 
-    return counts_list
+    return prob_list
 
 
 def build_result_snapshot(
@@ -538,10 +551,12 @@ def build_result_snapshot(
             elif "counts" in rt_lower or "sample" in rt_lower:
                 counts_list = _extract_sample_counts(results, num_circuits)
                 # PennyLane counts format
+                # NOTE: PennyLane uses wire[0] as leftmost bit in bitstrings
+                # This is cbit0_left (big-endian) in UEC terminology
                 counts_format = CountsFormat(
                     source_sdk="pennylane",
                     source_key_format="pennylane_bitstring",
-                    bit_order="cbit0_right",  # Canonical UEC format
+                    bit_order="cbit0_left",  # PennyLane native: wire[0] = leftmost
                     transformed=False,
                 )
                 for cd in counts_list:
@@ -557,22 +572,23 @@ def build_result_snapshot(
                         )
                     )
 
-            # Handle probabilities
+            # Handle probabilities - use quasi_probability (UEC v1.0 compliant)
             elif "probability" in rt_lower or "probs" in rt_lower:
                 probs_list = _extract_probabilities(results, num_circuits)
-                for cd in probs_list:
+                for pd in probs_list:
+                    # Create QuasiProbability with computed stats
+                    probs_values = list(pd.distribution.values())
+                    quasi = QuasiProbability(
+                        distribution=pd.distribution,
+                        sum_probs=sum(probs_values) if probs_values else None,
+                        min_prob=min(probs_values) if probs_values else None,
+                        max_prob=max(probs_values) if probs_values else None,
+                    )
                     items.append(
                         ResultItem(
-                            item_index=cd.circuit_index,
+                            item_index=pd.circuit_index,
                             success=True,
-                            counts={
-                                "counts": cd.counts,
-                                "shots": None,  # Probabilities don't have shots
-                                "format": {
-                                    "source_sdk": "pennylane",
-                                    "source_key_format": "probability_distribution",
-                                },
-                            },
+                            quasi_probability=quasi,
                         )
                     )
 

--- a/packages/devqubit-pennylane/tests/test_pennylane_adapter.py
+++ b/packages/devqubit-pennylane/tests/test_pennylane_adapter.py
@@ -108,11 +108,19 @@ class TestWrapDevice:
 
     def test_wrap_returns_same_device_patched(self, store, registry, default_qubit):
         """wrap() patches device in-place rather than returning wrapper."""
+
+        @qml.qnode(default_qubit, shots=10)
+        def simple_circuit():
+            qml.Hadamard(0)
+            return qml.counts(wires=[0])
+
         with track(project="pl", store=store, registry=registry) as run:
             wrapped = run.wrap(default_qubit)
             assert wrapped is default_qubit
             assert default_qubit._devqubit_patched is True
             assert default_qubit._devqubit_tracker is run
+            # Execute a circuit to create envelope (required for adapter runs)
+            _ = simple_circuit()
 
         loaded = registry.load(run.run_id)
         assert loaded.status == "FINISHED"

--- a/packages/devqubit-pennylane/tests/test_pennylane_adapter.py
+++ b/packages/devqubit-pennylane/tests/test_pennylane_adapter.py
@@ -7,7 +7,7 @@ import pennylane as qml
 from devqubit_engine.core.run import track
 from devqubit_pennylane.adapter import (
     PennyLaneAdapter,
-    _compute_circuit_hash,
+    _compute_structural_hash,
     patch_device,
 )
 
@@ -372,8 +372,8 @@ class TestCircuitHash:
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        assert _compute_circuit_hash(t1) == _compute_circuit_hash(t2)
-        assert _compute_circuit_hash(t1) != _compute_circuit_hash(t3)
+        assert _compute_structural_hash(t1) == _compute_structural_hash(t2)
+        assert _compute_structural_hash(t1) != _compute_structural_hash(t3)
 
     def test_different_wires_different_hash(self):
         """Different wire indices produce different hashes."""
@@ -385,7 +385,7 @@ class TestCircuitHash:
             qml.Hadamard(wires=1)
             qml.expval(qml.PauliZ(1))
 
-        assert _compute_circuit_hash(t1) != _compute_circuit_hash(t2)
+        assert _compute_structural_hash(t1) != _compute_structural_hash(t2)
 
     def test_different_measurements_different_hash(self):
         """Different measurement types produce different hashes."""
@@ -399,7 +399,9 @@ class TestCircuitHash:
             qml.probs(wires=0)
         tape_probs = qml.tape.QuantumScript.from_queue(q2)
 
-        assert _compute_circuit_hash(tape_expval) != _compute_circuit_hash(tape_probs)
+        assert _compute_structural_hash(tape_expval) != _compute_structural_hash(
+            tape_probs
+        )
 
     def test_single_tape_and_list_consistent(self):
         """Single tape and list of one tape produce same hash."""
@@ -408,8 +410,8 @@ class TestCircuitHash:
             qml.expval(qml.PauliZ(0))
         tape = qml.tape.QuantumScript.from_queue(q)
 
-        h_single = _compute_circuit_hash(tape)
-        h_list = _compute_circuit_hash([tape])
+        h_single = _compute_structural_hash(tape)
+        h_list = _compute_structural_hash([tape])
 
         assert h_single == h_list
 

--- a/packages/devqubit-qiskit-runtime/src/devqubit_qiskit_runtime/adapter.py
+++ b/packages/devqubit-qiskit-runtime/src/devqubit_qiskit_runtime/adapter.py
@@ -845,7 +845,7 @@ class TrackedRuntimePrimitive:
 
             self._logged_execution_count += 1
 
-        # Build ProgramSnapshot (UEC v1.0 compliant)
+        # Build ProgramSnapshot
         # Compute executed hashes from transpiled circuits if available
         executed_structural_hash = (
             compute_structural_hash(transpiled_circuits)

--- a/packages/devqubit-qiskit-runtime/src/devqubit_qiskit_runtime/circuits.py
+++ b/packages/devqubit-qiskit-runtime/src/devqubit_qiskit_runtime/circuits.py
@@ -14,7 +14,7 @@ import hashlib
 from typing import Any
 
 
-def compute_circuit_hash(circuits: list[Any]) -> str | None:
+def compute_structural_hash(circuits: list[Any]) -> str | None:
     """
     Compute a structure-only hash for Qiskit QuantumCircuit objects.
 
@@ -39,6 +39,8 @@ def compute_circuit_hash(circuits: list[Any]) -> str | None:
     - Ordered clbit indices (measurement wiring)
     - Parameter arity (count only, not values)
     - Classical condition presence
+
+    This is the STRUCTURAL hash - use compute_parametric_hash for full identity.
     """
     if not circuits:
         return None
@@ -80,6 +82,94 @@ def compute_circuit_hash(circuits: list[Any]) -> str | None:
 
                 op_sigs.append(
                     f"{op_name}|p{parity}|q{tuple(qs)}|c{tuple(cs)}|if{has_cond}"
+                )
+
+            circuit_signatures.append("||".join(op_sigs))
+
+        except Exception:
+            circuit_signatures.append(str(circuit)[:500])
+
+    payload = "\n".join(circuit_signatures).encode("utf-8", errors="replace")
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def compute_parametric_hash(circuits: list[Any]) -> str | None:
+    """
+    Compute a parametric hash for Qiskit QuantumCircuit objects.
+
+    Unlike structural hash, this includes actual parameter values,
+    making it suitable for identifying identical circuit executions.
+
+    Parameters
+    ----------
+    circuits : list[Any]
+        List of Qiskit QuantumCircuit objects.
+
+    Returns
+    -------
+    str or None
+        Full SHA-256 digest in format ``sha256:<hex>``, or None if empty.
+
+    Notes
+    -----
+    Includes:
+    - All structural information (gates, qubits, classical bits)
+    - Bound parameter values (rounded to 10 decimal places for stability)
+    - Unbound parameter names
+    """
+    if not circuits:
+        return None
+
+    circuit_signatures: list[str] = []
+
+    for circuit in circuits:
+        try:
+            qubit_index = {
+                q: i for i, q in enumerate(getattr(circuit, "qubits", ()) or ())
+            }
+            clbit_index = {
+                c: i for i, c in enumerate(getattr(circuit, "clbits", ()) or ())
+            }
+
+            op_sigs: list[str] = []
+            for instr in getattr(circuit, "data", []) or []:
+                op = getattr(instr, "operation", None)
+                name = getattr(op, "name", None)
+                op_name = name if isinstance(name, str) and name else type(op).__name__
+
+                qs: list[int] = []
+                for q in getattr(instr, "qubits", ()) or ():
+                    if q in qubit_index:
+                        qs.append(qubit_index[q])
+                    else:
+                        qs.append(getattr(circuit.find_bit(q), "index", -1))
+                cs: list[int] = []
+                for c in getattr(instr, "clbits", ()) or ():
+                    if c in clbit_index:
+                        cs.append(clbit_index[c])
+                    else:
+                        cs.append(getattr(circuit.find_bit(c), "index", -1))
+
+                # Include actual parameter values
+                params = getattr(op, "params", None) or []
+                param_strs: list[str] = []
+                for p in params:
+                    try:
+                        # Check if it's a Parameter (unbound)
+                        if hasattr(p, "name") and hasattr(p, "_symbol_expr"):
+                            param_strs.append(f"<param:{p.name}>")
+                        else:
+                            # Numeric value - round for stability
+                            val = float(p)
+                            param_strs.append(f"{val:.10f}")
+                    except (TypeError, ValueError):
+                        param_strs.append(str(p)[:50])
+
+                cond = getattr(op, "condition", None)
+                has_cond = 1 if cond is not None else 0
+
+                op_sigs.append(
+                    f"{op_name}|params=[{','.join(param_strs)}]|q{tuple(qs)}|c{tuple(cs)}|if{has_cond}"
                 )
 
             circuit_signatures.append("||".join(op_sigs))

--- a/packages/devqubit-qiskit/src/devqubit_qiskit/circuits.py
+++ b/packages/devqubit-qiskit/src/devqubit_qiskit/circuits.py
@@ -65,7 +65,7 @@ def materialize_circuits(circuits: Any) -> tuple[list[Any], bool]:
         return [circuits], True
 
 
-def compute_circuit_hash(circuits: list[Any]) -> str | None:
+def compute_structural_hash(circuits: list[Any]) -> str | None:
     """
     Compute a structure-only hash for Qiskit QuantumCircuit objects.
 
@@ -149,6 +149,93 @@ def compute_circuit_hash(circuits: list[Any]) -> str | None:
     return f"sha256:{hashlib.sha256(payload).hexdigest()}"
 
 
+def compute_parametric_hash(circuits: list[Any]) -> str | None:
+    """
+    Compute a parametric hash for Qiskit QuantumCircuit objects.
+
+    Unlike structural hash, this includes actual parameter values,
+    making it suitable for identifying identical circuit executions.
+
+    Parameters
+    ----------
+    circuits : list[Any]
+        List of Qiskit QuantumCircuit objects.
+
+    Returns
+    -------
+    str or None
+        Full SHA-256 digest in format ``sha256:<hex>``, or None if empty.
+
+    Notes
+    -----
+    Includes:
+    - All structural information (gates, qubits, classical bits)
+    - Bound parameter values (rounded to 10 decimal places for stability)
+    - Unbound parameter names
+    """
+    if not circuits:
+        return None
+
+    circuit_signatures: list[str] = []
+
+    for circuit in circuits:
+        try:
+            qubit_index = {
+                q: i for i, q in enumerate(getattr(circuit, "qubits", ()) or ())
+            }
+            clbit_index = {
+                c: i for i, c in enumerate(getattr(circuit, "clbits", ()) or ())
+            }
+
+            op_sigs: list[str] = []
+            for instr in getattr(circuit, "data", []) or []:
+                op = getattr(instr, "operation", None)
+                name = getattr(op, "name", None)
+                op_name = name if isinstance(name, str) and name else type(op).__name__
+
+                qs: list[int] = []
+                for q in getattr(instr, "qubits", ()) or ():
+                    if q in qubit_index:
+                        qs.append(qubit_index[q])
+                    else:
+                        qs.append(getattr(circuit.find_bit(q), "index", -1))
+                cs: list[int] = []
+                for c in getattr(instr, "clbits", ()) or ():
+                    if c in clbit_index:
+                        cs.append(clbit_index[c])
+                    else:
+                        cs.append(getattr(circuit.find_bit(c), "index", -1))
+
+                # Include actual parameter values
+                params = getattr(op, "params", None) or []
+                param_strs: list[str] = []
+                for p in params:
+                    try:
+                        # Check if it's a Parameter (unbound)
+                        if hasattr(p, "name") and hasattr(p, "_symbol_expr"):
+                            param_strs.append(f"<param:{p.name}>")
+                        else:
+                            val = float(p)
+                            param_strs.append(f"{val:.10f}")
+                    except (TypeError, ValueError):
+                        param_strs.append(str(p)[:50])
+
+                cond = getattr(op, "condition", None)
+                has_cond = 1 if cond is not None else 0
+
+                op_sigs.append(
+                    f"{op_name}|params=[{','.join(param_strs)}]|q{tuple(qs)}|c{tuple(cs)}|if{has_cond}"
+                )
+
+            circuit_signatures.append("||".join(op_sigs))
+
+        except Exception:
+            circuit_signatures.append(str(circuit)[:500])
+
+    payload = "\n".join(circuit_signatures).encode("utf-8", errors="replace")
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
 def circuits_to_text(circuits: list[Any]) -> str:
     """
     Convert circuits to human-readable text diagrams.
@@ -188,7 +275,7 @@ def serialize_and_log_circuits(
     tracker: Run,
     circuits: list[Any],
     backend_name: str,
-    circuit_hash: str | None,
+    structural_hash: str | None,
 ) -> list[ProgramArtifact]:
     """
     Serialize and log circuits in multiple formats.
@@ -204,8 +291,8 @@ def serialize_and_log_circuits(
         List of QuantumCircuit objects.
     backend_name : str
         Backend name for metadata.
-    circuit_hash : str or None
-        Circuit structure hash.
+    structural_hash : str or None
+        Structural hash of circuits (UEC v1.0).
 
     Returns
     -------
@@ -216,7 +303,7 @@ def serialize_and_log_circuits(
     meta = {
         "backend_name": backend_name,
         "qiskit_version": qiskit_version(),
-        "circuit_hash": circuit_hash,
+        "structural_hash": structural_hash,
         "num_circuits": len(circuits),
     }
 

--- a/packages/devqubit-qiskit/src/devqubit_qiskit/envelope.py
+++ b/packages/devqubit-qiskit/src/devqubit_qiskit/envelope.py
@@ -70,30 +70,37 @@ def detect_physical_provider(backend: Any) -> str:
 
 def create_program_snapshot(
     program_artifacts: list[ProgramArtifact],
-    circuit_hash: str | None,
+    structural_hash: str | None,
+    parametric_hash: str | None,
     num_circuits: int,
 ) -> ProgramSnapshot:
     """
-    Create a ProgramSnapshot from logged artifacts.
+    Create a ProgramSnapshot from logged artifacts (UEC v1.0 compliant).
 
     Parameters
     ----------
     program_artifacts : list of ProgramArtifact
         References to logged circuit artifacts.
-    circuit_hash : str or None
-        Circuit structure hash.
+    structural_hash : str or None
+        Structural hash of circuits (ignores parameter values).
+    parametric_hash : str or None
+        Parametric hash of circuits (includes parameter values).
     num_circuits : int
         Number of circuits in the program.
 
     Returns
     -------
     ProgramSnapshot
-        Program snapshot with artifact references.
+        Program snapshot with artifact references and hashes.
     """
     return ProgramSnapshot(
         logical=program_artifacts,
         physical=[],  # Base Qiskit adapter doesn't transpile
-        program_hash=circuit_hash,
+        structural_hash=structural_hash,
+        parametric_hash=parametric_hash,
+        # For base Qiskit without transpilation, executed hashes equal logical
+        executed_structural_hash=structural_hash,
+        executed_parametric_hash=parametric_hash,
         num_circuits=num_circuits,
     )
 

--- a/packages/devqubit-qiskit/tests/test_qiskit_adapter.py
+++ b/packages/devqubit-qiskit/tests/test_qiskit_adapter.py
@@ -14,7 +14,7 @@ from devqubit_qiskit.adapter import (
     TrackedJob,
 )
 from devqubit_qiskit.circuits import (
-    compute_circuit_hash,
+    compute_structural_hash,
     materialize_circuits,
 )
 from devqubit_qiskit.serialization import (
@@ -123,7 +123,7 @@ class TestCircuitHash:
         qc2.h(0)
         qc2.cx(0, 1)
 
-        assert compute_circuit_hash([qc1]) == compute_circuit_hash([qc2])
+        assert compute_structural_hash([qc1]) == compute_structural_hash([qc2])
 
     def test_different_gates_different_hash(self):
         """Different gates produce different hash."""
@@ -133,7 +133,7 @@ class TestCircuitHash:
         qc2 = QuantumCircuit(2)
         qc2.x(0)
 
-        assert compute_circuit_hash([qc1]) != compute_circuit_hash([qc2])
+        assert compute_structural_hash([qc1]) != compute_structural_hash([qc2])
 
     def test_parameter_values_dont_change_hash(self):
         """Parameter values don't affect structure hash."""
@@ -144,7 +144,7 @@ class TestCircuitHash:
         bound1 = qc.assign_parameters({theta: 0.5})
         bound2 = qc.assign_parameters({theta: 1.5})
 
-        assert compute_circuit_hash([bound1]) == compute_circuit_hash([bound2])
+        assert compute_structural_hash([bound1]) == compute_structural_hash([bound2])
 
 
 class TestTrackedBackendExecution:

--- a/packages/devqubit-qiskit/tests/test_qiskit_adapter.py
+++ b/packages/devqubit-qiskit/tests/test_qiskit_adapter.py
@@ -266,7 +266,11 @@ class TestEnvelopeStructure:
         assert "result" in envelope
 
     def test_envelope_device_section(
-        self, bell_circuit, aer_simulator, store, registry
+        self,
+        bell_circuit,
+        aer_simulator,
+        store,
+        registry,
     ):
         """Envelope device section has required fields."""
         with track(project="test", store=store, registry=registry) as run:
@@ -280,7 +284,11 @@ class TestEnvelopeStructure:
         assert "captured_at" in device
 
     def test_envelope_program_section(
-        self, bell_circuit, aer_simulator, store, registry
+        self,
+        bell_circuit,
+        aer_simulator,
+        store,
+        registry,
     ):
         """Envelope program section has circuit info."""
         with track(project="test", store=store, registry=registry) as run:
@@ -291,14 +299,17 @@ class TestEnvelopeStructure:
 
         program = envelope["program"]
         assert program["num_circuits"] == 1
-        assert program["program_hash"].startswith("sha256:")
+        assert program["structural_hash"].startswith("sha256:")
 
 
 class TestBatchQASM3Artifacts:
     """Multi-circuit batches must produce QASM3 artifact per circuit."""
 
     def test_batch_3_circuits_produces_3_qasm3_refs(
-        self, aer_simulator, store, registry
+        self,
+        aer_simulator,
+        store,
+        registry,
     ):
         """Batch of 3 circuits should produce 3 QASM3 artifacts."""
         circuits = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,7 @@ def make_run(registry: LocalRegistry, store: LocalStore) -> Callable[..., RunRec
     def _create(
         run_id: str | None = None,
         project: str = "test_project",
-        adapter: str = "qiskit",
+        adapter: str = "manual",
         backend: str = "aer_simulator",
         status: str = "FINISHED",
         params: dict[str, Any] | None = None,


### PR DESCRIPTION
## Summary
This PR makes the UEC ExecutionEnvelope the single source of truth for comparing and verifying runs across all supported SDKs. It introduces a clean split between structural and parametric program hashes, canonicalizes measurement keys across bit orders, removes the legacy strict mode, and enforces a production-grade rule: adapter runs must always emit a valid envelope, while manual/replay runs can have an envelope synthesized from run artifacts. This prevents “silent” fallbacks that mask adapter bugs and makes diffs stable and comparable across SDKs.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Refactor (no user-facing change)
- [ ] Docs only
- [ ] CI/build tooling
- [x] Breaking change

## Changelog
- [x] I added a towncrier fragment in `changelog.d/`

## Checklist
- [x] I ran lint locally (`uv run pre-commit run --all-files`)
- [x] I ran tests locally (`uv run pytest`)
- [x] I added/updated tests for behavior changes
- [ ] I updated docs/README/examples if needed
- [ ] If I changed dependencies, I updated `uv.lock` (`uv lock`) and committed it
- [x] I considered backward compatibility and security impact
