### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/devqubit-labs/devqubit/security/code-scanning/3](https://github.com/devqubit-labs/devqubit/security/code-scanning/3)

In general, the problem is fixed by explicitly defining a `permissions` block for the workflow or each job, restricting the `GITHUB_TOKEN` to the minimal rights needed. For this CI workflow, the jobs only read the repository contents (via `actions/checkout`) and run local commands; they don’t need any write access, so `contents: read` at the workflow root is sufficient and follows the principle of least privilege.

The single best fix with minimal functional impact is to add a top-level `permissions` block right after the `name: CI` line in `.github/workflows/ci.yaml`. This applies to all jobs (both `lint` and `test`) because neither currently defines its own `permissions`. Set `contents: read` as the only permission; that enables `actions/checkout` to function while avoiding unnecessary write permissions. No other lines or steps need to change, and no imports or additional definitions are required because this is purely a YAML configuration change.
