### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,9 @@ jobs:
     name: Build + test + package (all)
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/devqubit-labs/devqubit/security/code-scanning/2](https://github.com/devqubit-labs/devqubit/security/code-scanning/2)

In general, the fix is to explicitly declare a minimal `permissions` block for any workflow/job that uses `GITHUB_TOKEN`, instead of relying on repository defaults. For this workflow, only the `publish` job currently has explicit permissions; the `build` job should also define permissions, and since it only checks out code, runs tests, builds packages, and uploads artifacts, it only needs read access to repository contents.

Concretely, in `.github/workflows/release.yaml`, under `jobs.build` (alongside `runs-on`), add a `permissions` block with `contents: read`. This mirrors the recommended minimal starting point from CodeQL and does not alter functionality, because none of the steps depend on write privileges. No other files or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
