### PR TITLE
chore: harden adapters + tracking engforcing UEC envelopes and compute envelope-based fingerprints

### DIFF
--- a/packages/devqubit-braket/src/devqubit_braket/adapter.py
+++ b/packages/devqubit-braket/src/devqubit_braket/adapter.py
@@ -487,9 +487,14 @@ class TrackedDevice:
             self._logged_circuit_hashes.add(structural_hash)
         self._logged_execution_count += 1
 
+        # Get actual provider from envelope device snapshot
+        provider = "aws_braket"
+        if envelope.device and envelope.device.provider:
+            provider = envelope.device.provider
+
         # Set tracker tags/params
         self.tracker.set_tag("backend_name", device_name)
-        self.tracker.set_tag("provider", "aws_braket")
+        self.tracker.set_tag("provider", provider)
         self.tracker.set_tag("adapter", "devqubit-braket")
 
         if is_batch:
@@ -506,7 +511,7 @@ class TrackedDevice:
         self.tracker.record["backend"] = {
             "name": device_name,
             "type": self.device.__class__.__name__,
-            "provider": "aws_braket",
+            "provider": provider,
         }
 
         self.tracker.record["execute"] = {
@@ -631,10 +636,12 @@ class BraketAdapter:
         dict
             Device description with name, type, and provider.
         """
+        from devqubit_braket.device import _detect_physical_provider
+
         return {
             "name": get_backend_name(device),
             "type": device.__class__.__name__,
-            "provider": "aws_braket",
+            "provider": _detect_physical_provider(device),
         }
 
     def wrap_executor(

--- a/packages/devqubit-braket/tests/test_braket_device.py
+++ b/packages/devqubit-braket/tests/test_braket_device.py
@@ -264,6 +264,25 @@ class TestBackendTypeResolution:
 
 
 # =============================================================================
+# Provider Detection
+# =============================================================================
+
+
+class TestProviderDetection:
+    """Tests for physical provider detection."""
+
+    def test_local_simulator_provider_is_local(self, local_simulator):
+        """LocalSimulator has provider='local'."""
+        snap = create_device_snapshot(local_simulator)
+        assert snap.provider == "local"
+
+    def test_mock_aws_device_provider_is_aws(self, mock_device):
+        """Mock AWS device has provider='aws_braket'."""
+        snap = create_device_snapshot(mock_device)
+        assert snap.provider == "aws_braket"
+
+
+# =============================================================================
 # Error Handling
 # =============================================================================
 

--- a/packages/devqubit-cirq/src/devqubit_cirq/adapter.py
+++ b/packages/devqubit-cirq/src/devqubit_cirq/adapter.py
@@ -558,11 +558,9 @@ def _finalize_envelope_with_result(
         logger.debug("Failed to normalize counts payload: %s", e)
         counts_payload = {"experiments": []}
 
-    # Validate and log envelope
-    try:
-        tracker.log_envelope(envelope=envelope)
-    except Exception as e:
-        logger.warning("Failed to log envelope: %s", e)
+    # Validate and log envelope - EnvelopeValidationError must propagate
+    # to enforce strict validation for adapter runs
+    tracker.log_envelope(envelope=envelope)
 
     # Log normalized counts
     if counts_payload.get("experiments"):

--- a/packages/devqubit-engine/src/devqubit_engine/circuit/hashing.py
+++ b/packages/devqubit-engine/src/devqubit_engine/circuit/hashing.py
@@ -22,7 +22,9 @@ For circuits without parameters: ``parametric_hash == structural_hash``
 
 Encoding
 --------
+- Integers: "i:<decimal>" prefix preserves arbitrary precision
 - Floats: IEEE-754 binary64 big-endian hex
+- Booleans: "b:true" or "b:false"
 - Negative zero: normalized to positive zero
 - NaN: encoded as "nan"
 - Infinity: encoded as "inf" or "-inf"
@@ -85,10 +87,12 @@ def _encode_value(value: Any) -> str:
     """
     if value is None:
         return "__unbound__"
+    if isinstance(value, bool):
+        return f"b:{str(value).lower()}"
+    if isinstance(value, int):
+        return f"i:{value}"
     if isinstance(value, float):
         return _float_to_hex(value)
-    if isinstance(value, int):
-        return _float_to_hex(float(value))
     return str(value)
 
 

--- a/packages/devqubit-engine/src/devqubit_engine/schema/devqubit.envelope.1.0.schema.json
+++ b/packages/devqubit-engine/src/devqubit_engine/schema/devqubit.envelope.1.0.schema.json
@@ -344,7 +344,9 @@
             "completed",
             "failed",
             "cancelled",
-            "partial"
+            "partial",
+            "pending",
+            "running"
           ]
         },
         "items": {

--- a/packages/devqubit-engine/src/devqubit_engine/schema/devqubit.run.1.0.schema.json
+++ b/packages/devqubit-engine/src/devqubit_engine/schema/devqubit.run.1.0.schema.json
@@ -286,40 +286,19 @@
       "additionalProperties": false
     },
 
-    "digest_ptr": {
-      "type": "object",
-      "description": "Pointer to an artifact by (kind, digest).",
-      "required": ["kind", "digest"],
-      "properties": {
-        "kind": { "type": "string" },
-        "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
-      },
-      "additionalProperties": false
-    },
-
     "openqasm3_anchor": {
       "type": "object",
-      "description": "Anchor to OpenQASM3 raw/canonical artifacts for a single circuit/program.",
-      "required": ["index"],
+      "description": "Anchor to OpenQASM3 artifact for a single circuit/program.",
+      "required": ["index", "kind", "digest"],
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "index": { "type": "integer", "minimum": 0 },
-
-        "raw": { "$ref": "#/$defs/digest_ptr" },
-        "canonical": { "$ref": "#/$defs/digest_ptr" },
-
-        "canonicalization": {
-          "type": "object",
-          "description": "Metadata about canonicalization steps/warnings.",
-          "additionalProperties": true
-        }
+        "kind": { "type": "string", "minLength": 3 },
+        "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "media_type": { "type": "string", "minLength": 3 },
+        "role": { "type": "string", "minLength": 1 }
       },
-
-      "allOf": [
-        { "anyOf": [ { "required": ["raw"] }, { "required": ["canonical"] } ] }
-      ],
-
-      "additionalProperties": true
+      "additionalProperties": false
     },
 
     "param_value": {

--- a/packages/devqubit-engine/src/devqubit_engine/tracking/fingerprints.py
+++ b/packages/devqubit-engine/src/devqubit_engine/tracking/fingerprints.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 devqubit
+
+"""
+Run fingerprinting utilities.
+
+Fingerprints are computed from Envelope snapshots with volatile fields
+(timestamps, job IDs) excluded to ensure stable identifiers for
+reproducibility tracking.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from devqubit_engine.storage.artifacts.lookup import get_artifact_digests
+from devqubit_engine.utils.common import sha256_digest
+
+
+if TYPE_CHECKING:
+    from devqubit_engine.tracking.record import RunRecord
+    from devqubit_engine.uec.models.envelope import ExecutionEnvelope
+
+
+logger = logging.getLogger(__name__)
+
+
+def compute_fingerprints_from_envelope(envelope: ExecutionEnvelope) -> dict[str, str]:
+    """
+    Compute stable fingerprints from an ExecutionEnvelope.
+
+    Fingerprints are computed from Envelope snapshots with volatile fields
+    excluded. This ensures two runs with the same experimental setup produce
+    the same fingerprints regardless of when they were executed.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Envelope containing device, program, and execution snapshots.
+
+    Returns
+    -------
+    dict
+        Fingerprints dictionary with keys:
+
+        - ``program``: Hash of program hashes (structural + parametric)
+        - ``device``: Hash of backend identity (name, type, provider)
+        - ``intent``: Hash of execution config (shots, options, transpilation)
+        - ``run``: Combined hash of (program, device, intent)
+
+    Notes
+    -----
+    Volatile fields excluded from fingerprinting:
+
+    - ExecutionSnapshot: submitted_at, completed_at, job_ids, task_ids
+    - DeviceSnapshot: captured_at
+
+    The ``program`` fingerprint uses adapter-computed hashes when available.
+    These hashes capture circuit structure and parameter values in a
+    deterministic way that enables "same circuit?" comparison.
+
+    Post-transpilation hashes (``executed_structural_hash``,
+    ``executed_parametric_hash``) are available in the envelope for
+    advanced use cases but are not included in fingerprints.
+    """
+    # --- Program fingerprint ---
+    # Use hashes computed by adapter (they capture circuit semantics)
+    program_data: dict[str, Any] = {}
+    if envelope.program:
+        program_data = {
+            "structural_hash": envelope.program.structural_hash,
+            "parametric_hash": envelope.program.parametric_hash,
+            "num_circuits": envelope.program.num_circuits,
+        }
+    fp_program = sha256_digest({"program": program_data})
+
+    # --- Device fingerprint ---
+    # Backend identity without volatile captured_at
+    device_data: dict[str, Any] = {}
+    if envelope.device:
+        device_data = {
+            "backend_name": envelope.device.backend_name,
+            "backend_type": envelope.device.backend_type,
+            "provider": envelope.device.provider,
+            "backend_id": envelope.device.backend_id,
+            "num_qubits": envelope.device.num_qubits,
+        }
+    fp_device = sha256_digest({"device": device_data})
+
+    # --- Intent fingerprint ---
+    # Execution configuration without volatile fields
+    # Keep producer_sdk and execution_sdk separate for determinism
+    intent_data: dict[str, Any] = {
+        "adapter": envelope.producer.adapter,
+        "producer_sdk": envelope.producer.sdk,
+    }
+
+    if envelope.execution:
+        intent_data["shots"] = envelope.execution.shots
+        intent_data["options"] = envelope.execution.options
+        intent_data["execution_sdk"] = envelope.execution.sdk
+
+        # Include transpilation config (affects executed circuit)
+        if envelope.execution.transpilation:
+            intent_data["transpilation"] = {
+                "mode": (
+                    envelope.execution.transpilation.mode.value
+                    if hasattr(envelope.execution.transpilation.mode, "value")
+                    else str(envelope.execution.transpilation.mode)
+                ),
+                "optimization_level": envelope.execution.transpilation.optimization_level,
+                "layout_method": envelope.execution.transpilation.layout_method,
+                "routing_method": envelope.execution.transpilation.routing_method,
+                "seed": envelope.execution.transpilation.seed,
+            }
+
+    fp_intent = sha256_digest({"intent": intent_data})
+
+    # --- Combined run fingerprint ---
+    fp_run = sha256_digest(
+        {
+            "program": fp_program,
+            "device": fp_device,
+            "intent": fp_intent,
+        }
+    )
+
+    fingerprints: dict[str, str] = {
+        "program": fp_program,
+        "device": fp_device,
+        "intent": fp_intent,
+        "run": fp_run,
+    }
+
+    logger.debug("Computed fingerprints from envelope: run=%s...", fp_run[:16])
+    return fingerprints
+
+
+def compute_fingerprints_from_envelopes(
+    envelopes: list[ExecutionEnvelope],
+) -> dict[str, str]:
+    """
+    Compute stable fingerprints from multiple ExecutionEnvelopes.
+
+    For runs with multiple circuit batches (multi-envelope), fingerprints
+    are computed by aggregating data from all envelopes in a stable order.
+
+    Parameters
+    ----------
+    envelopes : list of ExecutionEnvelope
+        List of envelopes to compute fingerprints from. Must not be empty.
+        Envelopes are sorted by envelope_id for stable ordering.
+
+    Returns
+    -------
+    dict
+        Fingerprints dictionary with keys:
+
+        - ``program``: Hash of aggregated program data from all envelopes
+        - ``device``: Hash of aggregated device data from all envelopes
+        - ``intent``: Hash of aggregated intent data from all envelopes
+        - ``run``: Combined hash of (program, device, intent)
+
+    Raises
+    ------
+    ValueError
+        If envelopes list is empty.
+
+    Notes
+    -----
+    Aggregation strategy:
+
+    - Sort envelopes by ``envelope_id`` for deterministic ordering
+    - Collect program/device/intent data from each envelope
+    - Hash the sorted list of data dictionaries
+
+    This ensures that multi-circuit runs produce consistent fingerprints
+    regardless of the order envelopes were created.
+    """
+    if not envelopes:
+        raise ValueError("Cannot compute fingerprints from empty envelope list")
+
+    if len(envelopes) == 1:
+        return compute_fingerprints_from_envelope(envelopes[0])
+
+    # Sort envelopes by envelope_id for stable ordering
+    sorted_envelopes = sorted(envelopes, key=lambda e: e.envelope_id)
+
+    # Aggregate program data
+    program_data_list: list[dict[str, Any]] = []
+    for envelope in sorted_envelopes:
+        program_data: dict[str, Any] = {"envelope_id": envelope.envelope_id}
+        if envelope.program:
+            program_data.update(
+                {
+                    "structural_hash": envelope.program.structural_hash,
+                    "parametric_hash": envelope.program.parametric_hash,
+                    "num_circuits": envelope.program.num_circuits,
+                }
+            )
+        program_data_list.append(program_data)
+    fp_program = sha256_digest({"programs": program_data_list})
+
+    # Aggregate device data
+    device_data_list: list[dict[str, Any]] = []
+    for envelope in sorted_envelopes:
+        device_data: dict[str, Any] = {"envelope_id": envelope.envelope_id}
+        if envelope.device:
+            device_data.update(
+                {
+                    "backend_name": envelope.device.backend_name,
+                    "backend_type": envelope.device.backend_type,
+                    "provider": envelope.device.provider,
+                    "backend_id": envelope.device.backend_id,
+                    "num_qubits": envelope.device.num_qubits,
+                }
+            )
+        device_data_list.append(device_data)
+    fp_device = sha256_digest({"devices": device_data_list})
+
+    # Aggregate intent data
+    intent_data_list: list[dict[str, Any]] = []
+    for envelope in sorted_envelopes:
+        intent_data: dict[str, Any] = {
+            "envelope_id": envelope.envelope_id,
+            "adapter": envelope.producer.adapter,
+            "producer_sdk": envelope.producer.sdk,
+        }
+        if envelope.execution:
+            intent_data["shots"] = envelope.execution.shots
+            intent_data["options"] = envelope.execution.options
+            intent_data["execution_sdk"] = envelope.execution.sdk
+
+            if envelope.execution.transpilation:
+                intent_data["transpilation"] = {
+                    "mode": (
+                        envelope.execution.transpilation.mode.value
+                        if hasattr(envelope.execution.transpilation.mode, "value")
+                        else str(envelope.execution.transpilation.mode)
+                    ),
+                    "optimization_level": envelope.execution.transpilation.optimization_level,
+                    "layout_method": envelope.execution.transpilation.layout_method,
+                    "routing_method": envelope.execution.transpilation.routing_method,
+                    "seed": envelope.execution.transpilation.seed,
+                }
+        intent_data_list.append(intent_data)
+    fp_intent = sha256_digest({"intents": intent_data_list})
+
+    # Combined run fingerprint
+    fp_run = sha256_digest(
+        {
+            "program": fp_program,
+            "device": fp_device,
+            "intent": fp_intent,
+        }
+    )
+
+    fingerprints: dict[str, str] = {
+        "program": fp_program,
+        "device": fp_device,
+        "intent": fp_intent,
+        "run": fp_run,
+    }
+
+    logger.debug(
+        "Computed fingerprints from %d envelopes: run=%s...",
+        len(envelopes),
+        fp_run[:16],
+    )
+    return fingerprints
+
+
+def compute_fingerprints(
+    run: RunRecord,
+    envelope: ExecutionEnvelope | None = None,
+) -> dict[str, str]:
+    """
+    Compute stable fingerprints for a run record.
+
+    If an envelope is provided, fingerprints are computed from it.
+    Otherwise, falls back to artifact-based fingerprinting (limited).
+
+    Parameters
+    ----------
+    run : RunRecord
+        Run record (used for fallback if no envelope).
+    envelope : ExecutionEnvelope, optional
+        Envelope to compute fingerprints from. If provided, this is
+        the primary source for fingerprint computation.
+
+    Returns
+    -------
+    dict
+        Fingerprints dictionary with keys: program, device, intent, run.
+
+    Notes
+    -----
+    When envelope is available, fingerprints capture:
+
+    - Program identity via adapter-computed hashes
+    - Device identity via backend name/type/provider
+    - Execution intent via shots, options, transpilation config
+
+    Fallback (no envelope) provides limited fingerprints based on
+    artifact digests only.
+    """
+    # Use envelope if provided
+    if envelope is not None:
+        return compute_fingerprints_from_envelope(envelope)
+
+    # Fallback: artifact-based fingerprints (limited)
+    logger.debug("Computing fingerprints from artifacts (no envelope)")
+
+    record = run.record
+
+    # Program fingerprint from artifact digests
+    program_digests = get_artifact_digests(run, role="program")
+    fp_program = sha256_digest({"program_artifacts": program_digests})
+
+    # Device fingerprint from backend info in record
+    backend = record.get("backend") or {}
+    if not isinstance(backend, dict):
+        backend = {}
+
+    device_snapshot_digests = get_artifact_digests(run, role="device_snapshot")
+    device_raw_digests = get_artifact_digests(run, role="device_raw")
+    device_digests = sorted(set(device_snapshot_digests + device_raw_digests))
+
+    fp_device = sha256_digest(
+        {
+            "backend": {
+                "name": backend.get("name"),
+                "type": backend.get("type"),
+                "provider": backend.get("provider"),
+            },
+            "device_snapshots": device_digests,
+        }
+    )
+
+    # Intent fingerprint from adapter and envelope artifacts
+    intent_data: dict[str, Any] = {
+        "adapter": record.get("adapter"),
+    }
+
+    # Include shots from params if logged
+    params = run.params
+    if "shots" in params:
+        intent_data["shots"] = params["shots"]
+
+    # Include envelope artifact digests
+    envelope_digests = get_artifact_digests(run, role="envelope")
+    if envelope_digests:
+        intent_data["envelope_digests"] = sorted(envelope_digests)
+
+    fp_intent = sha256_digest(intent_data)
+
+    # Combined run fingerprint
+    fp_run = sha256_digest(
+        {
+            "program": fp_program,
+            "device": fp_device,
+            "intent": fp_intent,
+        }
+    )
+
+    fingerprints: dict[str, str] = {
+        "program": fp_program,
+        "device": fp_device,
+        "intent": fp_intent,
+        "run": fp_run,
+    }
+
+    logger.debug("Computed fingerprints from artifacts: run=%s...", fp_run[:16])
+    return fingerprints

--- a/packages/devqubit-engine/src/devqubit_engine/tracking/run.py
+++ b/packages/devqubit-engine/src/devqubit_engine/tracking/run.py
@@ -822,11 +822,14 @@ class Run:
                     raise TypeError("record['program']['openqasm3'] must be a list")
 
                 for item in out_items:
+                    ref = item["ref"]
                     entry: dict[str, Any] = {
                         "name": item["name"],
                         "index": int(item["index"]),
-                        "kind": item["ref"].kind,
-                        "digest": item["ref"].digest,
+                        "kind": ref.kind,
+                        "digest": ref.digest,
+                        "media_type": ref.media_type,
+                        "role": ref.role,
                     }
                     oq3_list.append(entry)
 

--- a/packages/devqubit-engine/src/devqubit_engine/tracking/run.py
+++ b/packages/devqubit-engine/src/devqubit_engine/tracking/run.py
@@ -37,21 +37,25 @@ Using the wrap pattern for automatic artifact logging:
 from __future__ import annotations
 
 import logging
+import threading
 import traceback as _tb
 from pathlib import Path
 from typing import Any, Sequence
 
 from devqubit_engine.config import Config, get_config
 from devqubit_engine.schema.validation import validate_run_record
-from devqubit_engine.storage.artifacts.lookup import get_artifact_digests
 from devqubit_engine.storage.factory import create_registry, create_store
 from devqubit_engine.storage.types import (
     ArtifactRef,
     ObjectStoreProtocol,
     RegistryProtocol,
 )
+from devqubit_engine.tracking.fingerprints import (
+    compute_fingerprints,
+    compute_fingerprints_from_envelopes,
+)
 from devqubit_engine.tracking.record import RunRecord
-from devqubit_engine.uec.errors import EnvelopeValidationError
+from devqubit_engine.uec.errors import EnvelopeValidationError, MissingEnvelopeError
 from devqubit_engine.uec.models.envelope import ExecutionEnvelope
 from devqubit_engine.utils.common import sha256_digest, utc_now_iso
 from devqubit_engine.utils.env import capture_environment, capture_git_provenance
@@ -62,139 +66,80 @@ from ulid import ULID
 
 logger = logging.getLogger(__name__)
 
+# Maximum artifact size in bytes (20 MB default)
+MAX_ARTIFACT_BYTES: int = 20 * 1024 * 1024
 
-def _strip_volatile_keys(obj: Any, *, volatile_keys: set[str]) -> Any:
+
+def _has_valid_envelope(artifacts: list) -> bool:
     """
-    Remove known volatile keys from nested mappings.
+    Check if a valid envelope artifact exists in the artifact list.
+
+    Only returns True if there is a valid envelope
+    (kind="devqubit.envelope.json"). Invalid envelopes
+    (kind="devqubit.envelope.invalid.json") are ignored.
 
     Parameters
     ----------
-    obj : Any
-        Object to process (dict, list, or scalar).
-    volatile_keys : set of str
-        Keys to strip from dictionaries.
+    artifacts : list of ArtifactRef
+        List of artifact references to check.
 
     Returns
     -------
-    Any
-        Processed object with volatile keys removed.
+    bool
+        True if at least one valid envelope artifact exists.
     """
-    if isinstance(obj, dict):
-        return {
-            k: _strip_volatile_keys(v, volatile_keys=volatile_keys)
-            for k, v in obj.items()
-            if k not in volatile_keys
-        }
-    if isinstance(obj, list):
-        return [_strip_volatile_keys(v, volatile_keys=volatile_keys) for v in obj]
-    return obj
+    for artifact in artifacts:
+        if artifact.role == "envelope" and artifact.kind == "devqubit.envelope.json":
+            return True
+    return False
 
 
-def _compute_fingerprints(run: RunRecord) -> dict[str, str]:
+def _synthesize_envelope_for_manual_run(
+    record: dict[str, Any],
+    artifacts: list,
+    store: ObjectStoreProtocol,
+) -> Any | None:
     """
-    Compute stable fingerprints for a run record.
+    Synthesize an envelope for a manual run.
 
-    Fingerprints enable reproducibility tracking by creating stable
-    identifiers for different aspects of the experiment.
+    This is called during finalization when a manual run doesn't have
+    an explicit envelope. The synthesized envelope has limited semantics
+    (no program hashes) but provides basic structure.
 
     Parameters
     ----------
-    run : RunRecord
-        Run record to fingerprint.
+    record : dict
+        Raw run record dictionary.
+    artifacts : list of ArtifactRef
+        Current artifact list.
+    store : ObjectStoreProtocol
+        Object store for artifact retrieval.
 
     Returns
     -------
-    dict
-        Fingerprints dictionary with keys:
+    ExecutionEnvelope or None
+        Synthesized envelope, or None if synthesis fails.
 
-        - ``program``: Hash of all program artifact digests (role="program")
-        - ``canonical_program``: Hash of canonical OpenQASM3 artifacts (if present)
-        - ``device``: Hash of backend identity + device_snapshot artifacts
-        - ``intent``: Hash of adapter + compile + execute config (volatile keys stripped)
-        - ``run``: Combined hash of (program, device, intent)
+    Notes
+    -----
+    The synthesized envelope will have:
+
+    - metadata.auto_generated=True
+    - metadata.manual_run=True (set by synthesize_envelope)
+    - No program hashes (engine cannot compute them)
     """
-    record = run.record
+    try:
+        from devqubit_engine.tracking.record import RunRecord
+        from devqubit_engine.uec.api.synthesize import synthesize_envelope
 
-    # Program fingerprint: all program artifacts (QPY, QASM, etc.)
-    program_digests = get_artifact_digests(run, role="program")
-    fp_program = sha256_digest({"program_artifacts": program_digests})
+        temp_record = RunRecord(record=record, artifacts=artifacts)
+        envelope = synthesize_envelope(temp_record, store)
+        envelope.metadata["auto_generated"] = True
+        return envelope
 
-    # Canonical program fingerprint: only canonical OpenQASM3 artifacts
-    canonical_digests = get_artifact_digests(
-        run,
-        role="program",
-        kind_contains="openqasm3.canonical",
-    )
-    fp_canonical: str | None = None
-    if canonical_digests:
-        fp_canonical = sha256_digest({"program_artifacts": canonical_digests})
-
-    # Device fingerprint
-    backend = record.get("backend") or {}
-    if not isinstance(backend, dict):
-        backend = {}
-
-    device_snapshot_digests = get_artifact_digests(run, role="device_snapshot")
-    device_raw_digests = get_artifact_digests(run, role="device_raw")
-    device_digests = sorted(set(device_snapshot_digests + device_raw_digests))
-
-    fp_device = sha256_digest(
-        {
-            "backend": {
-                "name": backend.get("name"),
-                "type": backend.get("type"),
-                "provider": backend.get("provider"),
-            },
-            "device_snapshots": device_digests,
-        }
-    )
-
-    # Intent fingerprint (execution configuration)
-    execute_raw = record.get("execute") or {}
-    if not isinstance(execute_raw, dict):
-        execute_raw = {}
-
-    # Strip volatile keys that change between runs
-    volatile_execute_keys = {
-        "submitted_at",
-        "job_id",
-        "job_ids",
-        "completed_at",
-        "session_id",
-    }
-
-    fp_intent = sha256_digest(
-        {
-            "adapter": record.get("adapter"),
-            "compile": record.get("compile") or {},
-            "execute": _strip_volatile_keys(
-                execute_raw,
-                volatile_keys=volatile_execute_keys,
-            ),
-        }
-    )
-
-    # Combined run fingerprint
-    fp_run = sha256_digest(
-        {
-            "program": fp_program,
-            "device": fp_device,
-            "intent": fp_intent,
-        }
-    )
-
-    fingerprints: dict[str, str] = {
-        "program": fp_program,
-        "device": fp_device,
-        "intent": fp_intent,
-        "run": fp_run,
-    }
-
-    if fp_canonical is not None:
-        fingerprints["canonical_program"] = fp_canonical
-
-    logger.debug("Computed fingerprints: run=%s...", fp_run[:16])
-    return fingerprints
+    except Exception as e:
+        logger.warning("Failed to synthesize envelope: %s", e)
+        return None
 
 
 class Run:
@@ -244,27 +189,6 @@ class Run:
         Run registry for metadata.
     record : dict
         Raw run record dictionary.
-
-    Examples
-    --------
-    Basic tracking:
-
-    >>> with Run(project="bell_state") as run:
-    ...     run.log_param("shots", 1000)
-    ...     run.log_metric("fidelity", 0.95)
-
-    Grouped runs for parameter sweep:
-
-    >>> sweep_id = "sweep_20240101"
-    >>> for shots in [100, 1000, 10000]:
-    ...     with Run(project="bell_state", group_id=sweep_id) as run:
-    ...         run.log_param("shots", shots)
-    ...         # ... run experiment ...
-
-    See Also
-    --------
-    track : Convenience function for creating runs.
-    wrap_backend : Wrap backend for automatic artifact logging.
     """
 
     def __init__(
@@ -281,6 +205,9 @@ class Run:
         group_name: str | None = None,
         parent_run_id: str | None = None,
     ) -> None:
+        # Thread-safety lock for record and artifact mutations
+        self._lock = threading.Lock()
+
         # Generate unique run ID
         ulid_gen = ULID()
         self._run_id = (
@@ -403,7 +330,9 @@ class Run:
         value : Any
             Parameter value. Will be converted to JSON-serializable form.
         """
-        self.record["data"]["params"][key] = to_jsonable(value)
+        jsonable_value = to_jsonable(value)
+        with self._lock:
+            self.record["data"]["params"][key] = jsonable_value
         logger.debug("Logged param: %s=%r", key, value)
 
     def log_params(self, params: dict[str, Any]) -> None:
@@ -453,23 +382,25 @@ class Run:
                 raise ValueError(f"step must be non-negative, got {step}")
 
             # Time series mode
-            if "metric_series" not in self.record["data"]:
-                self.record["data"]["metric_series"] = {}
+            with self._lock:
+                if "metric_series" not in self.record["data"]:
+                    self.record["data"]["metric_series"] = {}
 
-            if key not in self.record["data"]["metric_series"]:
-                self.record["data"]["metric_series"][key] = []
+                if key not in self.record["data"]["metric_series"]:
+                    self.record["data"]["metric_series"][key] = []
 
-            self.record["data"]["metric_series"][key].append(
-                {
-                    "value": value_f,
-                    "step": step,
-                    "timestamp": utc_now_iso(),
-                }
-            )
+                self.record["data"]["metric_series"][key].append(
+                    {
+                        "value": value_f,
+                        "step": step,
+                        "timestamp": utc_now_iso(),
+                    }
+                )
             logger.debug("Logged metric series: %s[%d]=%f", key, step, value_f)
         else:
             # Scalar mode (overwrites previous value)
-            self.record["data"]["metrics"][key] = value_f
+            with self._lock:
+                self.record["data"]["metrics"][key] = value_f
             logger.debug("Logged metric: %s=%f", key, value_f)
 
     def log_metrics(self, metrics: dict[str, float]) -> None:
@@ -497,7 +428,9 @@ class Run:
         value : str
             Tag value (will be converted to string).
         """
-        self.record["data"]["tags"][key] = str(value)
+        str_value = str(value)
+        with self._lock:
+            self.record["data"]["tags"][key] = str_value
         logger.debug("Set tag: %s=%s", key, value)
 
     def set_tags(self, tags: dict[str, str]) -> None:
@@ -511,32 +444,6 @@ class Run:
         """
         for key, value in tags.items():
             self.set_tag(key, value)
-
-    def log_compile(self, config: dict[str, Any]) -> None:
-        """
-        Record compile/transpile configuration.
-
-        Parameters
-        ----------
-        config : dict
-            Compilation configuration (e.g., optimization_level,
-            seed_transpiler, routing_method, basis_gates).
-        """
-        self.record["compile"] = to_jsonable(config)
-        logger.debug("Logged compile config")
-
-    def log_execute(self, config: dict[str, Any]) -> None:
-        """
-        Record execution configuration.
-
-        Parameters
-        ----------
-        config : dict
-            Execution configuration (e.g., shots, resilience_level,
-            error_mitigation options, dynamic decoupling).
-        """
-        self.record["execute"] = to_jsonable(config)
-        logger.debug("Logged execute config")
 
     def log_text(
         self,
@@ -590,6 +497,9 @@ class Run:
         media_type: str,
         role: str = "artifact",
         meta: dict[str, Any] | None = None,
+        *,
+        max_bytes: int | None = None,
+        truncate: bool = False,
     ) -> ArtifactRef:
         """
         Log a binary artifact.
@@ -607,12 +517,47 @@ class Run:
             Common values: "program", "results", "device_snapshot".
         meta : dict, optional
             Additional metadata.
+        max_bytes : int, optional
+            Maximum allowed size in bytes. Defaults to ``MAX_ARTIFACT_BYTES``.
+            Set to 0 or negative to disable size limit.
+        truncate : bool, optional
+            If True and data exceeds max_bytes, truncate data and add
+            a digest of full content to metadata. If False (default),
+            raise ValueError for oversized artifacts.
 
         Returns
         -------
         ArtifactRef
             Reference to the stored artifact.
+
+        Raises
+        ------
+        ValueError
+            If data exceeds max_bytes and truncate is False.
         """
+        limit = max_bytes if max_bytes is not None else MAX_ARTIFACT_BYTES
+        size = len(data)
+
+        if limit > 0 and size > limit:
+            if truncate:
+                full_digest = sha256_digest(data)
+                data = data[:limit]
+                meta = dict(meta) if meta else {}
+                meta["truncated"] = True
+                meta["original_size"] = size
+                meta["original_digest"] = full_digest
+                logger.warning(
+                    "Artifact truncated: kind=%s, original_size=%d, limit=%d",
+                    kind,
+                    size,
+                    limit,
+                )
+            else:
+                raise ValueError(
+                    f"Artifact size ({size} bytes) exceeds limit ({limit} bytes). "
+                    f"Set truncate=True to allow truncation or increase max_bytes."
+                )
+
         digest = self._store.put_bytes(data)
         ref = ArtifactRef(
             kind=kind,
@@ -621,7 +566,8 @@ class Run:
             role=role,
             meta=meta,
         )
-        self._artifacts.append(ref)
+        with self._lock:
+            self._artifacts.append(ref)
         logger.debug(
             "Logged artifact: kind=%s, role=%s, digest=%s...", kind, role, digest[:24]
         )
@@ -662,101 +608,6 @@ class Run:
             meta={"name": name},
         )
 
-    def log_counts(
-        self,
-        counts: dict[str, int],
-        *,
-        shots: int | None = None,
-        source_sdk: str = "manual",
-        bit_order: str = "cbit0_right",
-        experiment_index: int = 0,
-        transform_to_canonical: bool = False,
-    ) -> ArtifactRef:
-        """
-        Log measurement counts as a standardized artifact.
-
-        This helper simplifies manual logging of quantum execution results
-        by ensuring counts are stored in a consistent format compatible
-        with compare/diff operations.
-
-        Parameters
-        ----------
-        counts : dict
-            Measurement counts as {bitstring: count} mapping.
-            Keys should be binary strings (e.g., "00", "01", "10", "11").
-        shots : int, optional
-            Total number of shots. If None, computed from counts.
-        source_sdk : str, default="manual"
-            SDK that produced the counts (e.g., "qiskit", "braket", "manual").
-        bit_order : str, default="cbit0_right"
-            Bit ordering convention of the counts keys.
-            - "cbit0_right": LSB on right (Qiskit convention, canonical)
-            - "cbit0_left": LSB on left (Braket/Cirq convention)
-        experiment_index : int, default=0
-            Experiment index for batch executions.
-        transform_to_canonical : bool, default=False
-            If True and bit_order is "cbit0_left", reverse bitstrings
-            to canonical "cbit0_right" format.
-
-        Returns
-        -------
-        ArtifactRef
-            Reference to the stored counts artifact.
-
-        Notes
-        -----
-        The canonical bit order for devqubit is "cbit0_right" (little-endian,
-        LSB on right), which matches Qiskit's convention. If your counts come
-        from Braket or Cirq (big-endian), set transform_to_canonical=True
-        to convert them.
-        """
-        # Compute shots if not provided
-        if shots is None:
-            shots = sum(counts.values())
-
-        # Transform to canonical bit order if requested
-        transformed = False
-        final_counts = counts
-        if transform_to_canonical and bit_order == "cbit0_left":
-            final_counts = {k[::-1]: v for k, v in counts.items()}
-            transformed = True
-            bit_order = "cbit0_right"
-
-        # Build payload in standard format
-        payload = {
-            "counts": final_counts,
-            "shots": shots,
-            "experiments": [
-                {
-                    "index": experiment_index,
-                    "counts": final_counts,
-                    "shots": shots,
-                }
-            ],
-            "counts_format": {
-                "source_sdk": source_sdk,
-                "source_key_format": f"{source_sdk}_counts",
-                "bit_order": bit_order,
-                "transformed": transformed,
-            },
-        }
-
-        ref = self.log_json(
-            name="result_counts",
-            obj=payload,
-            role="results",
-            kind="result.counts.json",
-        )
-
-        logger.debug(
-            "Logged counts: shots=%d, outcomes=%d, source_sdk=%s",
-            shots,
-            len(final_counts),
-            source_sdk,
-        )
-
-        return ref
-
     def log_envelope(self, envelope: ExecutionEnvelope) -> bool:
         """
         Validate and log execution envelope.
@@ -766,6 +617,8 @@ class Run:
 
         For adapter runs, invalid envelope raises EnvelopeValidationError.
         For manual runs, invalid envelope is logged but execution continues.
+
+        Multiple envelopes per run are allowed (e.g., one per circuit batch).
 
         Parameters
         ----------
@@ -781,6 +634,7 @@ class Run:
         ------
         EnvelopeValidationError
             If adapter run produces invalid envelope (strict enforcement).
+            This error MUST NOT be silenced by adapters.
         """
         # Validate envelope
         validation = envelope.validate_schema()
@@ -829,10 +683,11 @@ class Run:
             )
 
             # Store summary in tracker record for visibility
-            self.record["envelope_validation_error"] = {
-                "errors": [str(e) for e in validation.errors],
-                "count": validation.error_count,
-            }
+            with self._lock:
+                self.record["envelope_validation_error"] = {
+                    "errors": [str(e) for e in validation.errors],
+                    "count": validation.error_count,
+                }
 
             # Log invalid envelope for debugging
             self.log_json(
@@ -1007,34 +862,35 @@ class Run:
 
         # Anchor pointers in the run record
         if anchor:
-            prog = self.record.setdefault("program", {})
-            oq3_list = prog.setdefault("openqasm3", [])
+            with self._lock:
+                prog = self.record.setdefault("program", {})
+                oq3_list = prog.setdefault("openqasm3", [])
 
-            if not isinstance(oq3_list, list):
-                raise TypeError("record['program']['openqasm3'] must be a list")
+                if not isinstance(oq3_list, list):
+                    raise TypeError("record['program']['openqasm3'] must be a list")
 
-            for item in out_items:
-                entry: dict[str, Any] = {
-                    "name": item["name"],
-                    "index": int(item["index"]),
-                }
-
-                if item.get("raw_ref") is not None:
-                    entry["raw"] = {
-                        "kind": item["raw_ref"].kind,
-                        "digest": item["raw_ref"].digest,
+                for item in out_items:
+                    entry: dict[str, Any] = {
+                        "name": item["name"],
+                        "index": int(item["index"]),
                     }
 
-                if item.get("canonical_ref") is not None:
-                    entry["canonical"] = {
-                        "kind": item["canonical_ref"].kind,
-                        "digest": item["canonical_ref"].digest,
-                    }
+                    if item.get("raw_ref") is not None:
+                        entry["raw"] = {
+                            "kind": item["raw_ref"].kind,
+                            "digest": item["raw_ref"].digest,
+                        }
 
-                if item.get("canonical_info") is not None:
-                    entry["canonicalization"] = item["canonical_info"]
+                    if item.get("canonical_ref") is not None:
+                        entry["canonical"] = {
+                            "kind": item["canonical_ref"].kind,
+                            "digest": item["canonical_ref"].digest,
+                        }
 
-                oq3_list.append(entry)
+                    if item.get("canonical_info") is not None:
+                        entry["canonicalization"] = item["canonical_info"]
+
+                    oq3_list.append(entry)
 
         result: dict[str, Any] = {"items": out_items}
 
@@ -1082,20 +938,17 @@ class Run:
         >>> with track(project="test") as run:
         ...     backend = run.wrap(AerSimulator())
         ...     job = backend.run(circuit)
-
-        See Also
-        --------
-        wrap_backend : Standalone convenience function.
         """
         from devqubit_engine.adapters import resolve_adapter
 
         adapter = resolve_adapter(executor)
 
-        self.record["adapter"] = adapter.name
-        self._adapter = adapter.name
+        with self._lock:
+            self.record["adapter"] = adapter.name
+            self._adapter = adapter.name
 
-        desc = adapter.describe_executor(executor)
-        self.record["backend"] = desc
+            desc = adapter.describe_executor(executor)
+            self.record["backend"] = desc
 
         logger.debug("Wrapped executor with adapter: %s", adapter.name)
         return adapter.wrap_executor(executor, self, **kwargs)
@@ -1123,8 +976,9 @@ class Run:
             Status to set. Default is "FAILED". Use "KILLED" for
             interrupts.
         """
-        self.record["info"]["status"] = status
-        self.record["info"]["ended_at"] = utc_now_iso()
+        with self._lock:
+            self.record["info"]["status"] = status
+            self.record["info"]["ended_at"] = utc_now_iso()
 
         if error is None:
             logger.info("Run marked as %s: %s", status, self._run_id)
@@ -1134,13 +988,14 @@ class Run:
         tb = exc_tb if exc_tb is not None else getattr(error, "__traceback__", None)
         formatted = "".join(_tb.format_exception(etype, error, tb))
 
-        self.record.setdefault("errors", []).append(
-            {
-                "type": etype.__name__,
-                "message": str(error),
-                "traceback": formatted,
-            }
-        )
+        with self._lock:
+            self.record.setdefault("errors", []).append(
+                {
+                    "type": etype.__name__,
+                    "message": str(error),
+                    "traceback": formatted,
+                }
+            )
 
         logger.warning(
             "Run %s: %s - %s: %s",
@@ -1163,13 +1018,8 @@ class Run:
         bool
             True if valid envelope artifact exists in self._artifacts.
         """
-        for artifact in self._artifacts:
-            if (
-                artifact.role == "envelope"
-                and artifact.kind == "devqubit.envelope.json"
-            ):
-                return True
-        return False
+        with self._lock:
+            return _has_valid_envelope(self._artifacts)
 
     def _ensure_envelope(self) -> None:
         """
@@ -1203,18 +1053,19 @@ class Run:
             adapter = self.record.get("adapter", "unknown")
 
             # Mark run as FAILED with structured error
-            self.record["info"]["status"] = "FAILED"
-            self.record.setdefault("errors", []).append(
-                {
-                    "type": "MissingExecutionEnvelope",
-                    "message": (
-                        f"Adapter run (adapter={adapter}) completed without "
-                        f"creating execution envelope. This is an adapter "
-                        f"integration error - adapters must create envelopes."
-                    ),
-                    "adapter": adapter,
-                }
-            )
+            with self._lock:
+                self.record["info"]["status"] = "FAILED"
+                self.record.setdefault("errors", []).append(
+                    {
+                        "type": "MissingExecutionEnvelope",
+                        "message": (
+                            f"Adapter run (adapter={adapter}) completed without "
+                            f"creating execution envelope. This is an adapter "
+                            f"integration error - adapters must create envelopes."
+                        ),
+                        "adapter": adapter,
+                    }
+                )
 
             logger.error(
                 "Adapter run '%s' (adapter=%s) completing without envelope. "
@@ -1225,22 +1076,15 @@ class Run:
             return
 
         # Build envelope for manual run
-        try:
-            from devqubit_engine.uec.api.synthesize import (
-                synthesize_envelope,
-            )
+        with self._lock:
+            record_copy = dict(self.record)
+            artifacts_copy = list(self._artifacts)
 
-            # Create temporary RunRecord for envelope building
-            temp_record = RunRecord(
-                record=self.record,
-                artifacts=self._artifacts,
-            )
+        envelope = _synthesize_envelope_for_manual_run(
+            record=record_copy, artifacts=artifacts_copy, store=self._store
+        )
 
-            envelope = synthesize_envelope(temp_record, self._store)
-
-            # Mark as auto-generated (keep manual_run from synthesize_envelope)
-            envelope.metadata["auto_generated"] = True
-
+        if envelope is not None:
             # Log the envelope (skip validation for auto-generated)
             self.log_json(
                 name="execution_envelope",
@@ -1248,19 +1092,80 @@ class Run:
                 role="envelope",
                 kind="devqubit.envelope.json",
             )
-
             logger.debug(
                 "Auto-generated envelope for manual run %s",
                 self._run_id,
             )
+        else:
+            logger.warning(
+                "Failed to auto-generate envelope for run %s",
+                self._run_id,
+            )
+
+    def _compute_fingerprints(self, run_record: RunRecord) -> dict[str, str]:
+        """
+        Compute fingerprints using canonical envelope resolution.
+
+        Uses the canonical resolver (load_all_envelopes) to load envelopes
+        and compute fingerprints. Handles errors gracefully by returning
+        empty fingerprints and marking the run as FAILED.
+
+        Parameters
+        ----------
+        run_record : RunRecord
+            Run record with artifacts.
+
+        Returns
+        -------
+        dict
+            Fingerprints dictionary. Empty dict if envelope resolution fails.
+        """
+        from devqubit_engine.uec.api.resolve import load_all_envelopes
+
+        try:
+            envelopes = load_all_envelopes(run_record, self._store)
+
+            if not envelopes:
+                # No envelopes found - use artifact-based fallback
+                logger.debug("No envelopes found, using artifact-based fingerprints")
+                return compute_fingerprints(run_record, envelope=None)
+
+            if len(envelopes) == 1:
+                return compute_fingerprints(run_record, envelope=envelopes[0])
+
+            # Multi-envelope: aggregate fingerprints
+            return compute_fingerprints_from_envelopes(envelopes)
+
+        except (MissingEnvelopeError, EnvelopeValidationError) as e:
+            adapter = self.record.get("adapter", "unknown")
+            error_type = type(e).__name__
+
+            with self._lock:
+                self.record["info"]["status"] = "FAILED"
+                self.record.setdefault("errors", []).append(
+                    {
+                        "type": error_type,
+                        "message": str(e),
+                        "adapter": adapter,
+                    }
+                )
+
+            logger.error(
+                "Envelope error during fingerprinting for run '%s': %s - %s",
+                self._run_id,
+                error_type,
+                str(e),
+            )
+            return {}
 
         except Exception as e:
-            # Don't fail the run if envelope generation fails for manual runs
             logger.warning(
-                "Failed to auto-generate envelope for run %s: %s",
+                "Unexpected error computing fingerprints for run '%s': %s",
                 self._run_id,
                 e,
             )
+            # Fall back to artifact-based fingerprints
+            return compute_fingerprints(run_record, envelope=None)
 
     def _finalize(self, success: bool = True) -> None:
         """
@@ -1271,19 +1176,23 @@ class Run:
         success : bool, optional
             If True and status is "RUNNING", set to "FINISHED".
         """
-        if success and self.record["info"]["status"] == "RUNNING":
-            self.record["info"]["status"] = "FINISHED"
-            self.record["info"]["ended_at"] = utc_now_iso()
+        with self._lock:
+            if success and self.record["info"]["status"] == "RUNNING":
+                self.record["info"]["status"] = "FINISHED"
+                self.record["info"]["ended_at"] = utc_now_iso()
 
         # Ensure envelope exists (auto-generate if needed)
         self._ensure_envelope()
 
-        # Serialize artifacts
-        self.record["artifacts"] = [a.to_dict() for a in self._artifacts]
+        # Serialize artifacts and compute fingerprints
+        with self._lock:
+            self.record["artifacts"] = [a.to_dict() for a in self._artifacts]
+            run_record = RunRecord(record=self.record, artifacts=list(self._artifacts))
 
-        # Build RunRecord and compute fingerprints
-        run_record = RunRecord(record=self.record, artifacts=self._artifacts)
-        self.record["fingerprints"] = _compute_fingerprints(run_record)
+        # Compute fingerprints using canonical envelope resolution
+        fingerprints = self._compute_fingerprints(run_record)
+        with self._lock:
+            self.record["fingerprints"] = fingerprints
 
         # Validate if enabled
         if self._config.validate:
@@ -1329,6 +1238,24 @@ class Run:
                 self._finalize(success=False)
             except Exception as finalize_error:
                 # Best-effort: preserve original exception, record finalization error
+                with self._lock:
+                    self.record.setdefault("errors", []).append(
+                        {
+                            "type": type(finalize_error).__name__,
+                            "message": f"Finalization error: {finalize_error}",
+                            "traceback": _tb.format_exc(),
+                        }
+                    )
+                logger.exception("Error during run finalization")
+
+            return False  # Propagate original exception
+
+        # Success path - wrap in try/except for robustness
+        try:
+            self._finalize(success=True)
+        except Exception as finalize_error:
+            # Best-effort: record error but don't raise on exit
+            with self._lock:
                 self.record.setdefault("errors", []).append(
                     {
                         "type": type(finalize_error).__name__,
@@ -1336,11 +1263,14 @@ class Run:
                         "traceback": _tb.format_exc(),
                     }
                 )
-                logger.exception("Error during run finalization")
+            logger.exception("Error during run finalization (success path)")
 
-            return False  # Propagate original exception
+            # Attempt to save the run record even with incomplete data
+            try:
+                self._registry.save(self.record)
+            except Exception:
+                logger.exception("Failed to save run record after finalization error")
 
-        self._finalize(success=True)
         return False
 
     def __repr__(self) -> str:
@@ -1454,11 +1384,6 @@ def wrap_backend(run: Run, backend: Any, **kwargs: Any) -> Any:
     ------
     ValueError
         If no adapter supports the given backend type.
-
-    See Also
-    --------
-    Run.wrap : Equivalent method on the Run class.
-    track : Context manager for creating tracked runs.
 
     Examples
     --------

--- a/packages/devqubit-engine/src/devqubit_engine/tracking/run.py
+++ b/packages/devqubit-engine/src/devqubit_engine/tracking/run.py
@@ -103,8 +103,8 @@ def _synthesize_envelope_for_manual_run(
     Synthesize an envelope for a manual run.
 
     This is called during finalization when a manual run doesn't have
-    an explicit envelope. The synthesized envelope has limited semantics
-    (no program hashes) but provides basic structure.
+    an explicit envelope. The synthesized envelope provides basic structure
+    with limited semantics compared to adapter-generated envelopes.
 
     Parameters
     ----------
@@ -126,7 +126,8 @@ def _synthesize_envelope_for_manual_run(
 
     - metadata.auto_generated=True
     - metadata.manual_run=True (set by synthesize_envelope)
-    - No program hashes (engine cannot compute them)
+    - program.structural_hash computed from artifact digests (not circuit structure)
+    - program.parametric_hash is None (engine cannot compute)
     """
     try:
         from devqubit_engine.tracking.record import RunRecord

--- a/packages/devqubit-engine/src/devqubit_engine/uec/models/result.py
+++ b/packages/devqubit-engine/src/devqubit_engine/uec/models/result.py
@@ -528,12 +528,21 @@ class ResultSnapshot:
 
     schema_version: str = "devqubit.result_snapshot/1.0"
 
+    #: Valid status values for ResultSnapshot.
+    VALID_STATUSES: tuple[str, ...] = (
+        "completed",
+        "failed",
+        "cancelled",
+        "partial",
+        "pending",
+        "running",
+    )
+
     def __post_init__(self) -> None:
         """Validate status values."""
-        valid_statuses = ("completed", "failed", "cancelled", "partial")
-        if self.status not in valid_statuses:
+        if self.status not in self.VALID_STATUSES:
             raise ValueError(
-                f"status must be one of {valid_statuses}, got: {self.status}"
+                f"status must be one of {self.VALID_STATUSES}, got: {self.status}"
             )
 
     def to_dict(self) -> dict[str, Any]:
@@ -673,6 +682,56 @@ class ResultSnapshot:
             status="partial",
             items=items,
             error=error,
+            metadata=metadata or {},
+        )
+
+    @classmethod
+    def create_pending(
+        cls,
+        metadata: dict[str, Any] | None = None,
+    ) -> ResultSnapshot:
+        """
+        Create pending result snapshot (job submitted, awaiting execution).
+
+        Parameters
+        ----------
+        metadata : dict, optional
+            Additional metadata (e.g., job_id, queue_position).
+
+        Returns
+        -------
+        ResultSnapshot
+            Pending result snapshot.
+        """
+        return cls(
+            success=False,
+            status="pending",
+            items=[],
+            metadata=metadata or {},
+        )
+
+    @classmethod
+    def create_running(
+        cls,
+        metadata: dict[str, Any] | None = None,
+    ) -> ResultSnapshot:
+        """
+        Create running result snapshot (job currently executing).
+
+        Parameters
+        ----------
+        metadata : dict, optional
+            Additional metadata (e.g., progress, estimated_completion).
+
+        Returns
+        -------
+        ResultSnapshot
+            Running result snapshot.
+        """
+        return cls(
+            success=False,
+            status="running",
+            items=[],
             metadata=metadata or {},
         )
 

--- a/packages/devqubit-engine/tests/test_circuit.py
+++ b/packages/devqubit-engine/tests/test_circuit.py
@@ -402,6 +402,32 @@ class TestCircuitHashing:
         h2 = hash_structural(ops, 2, 0)
         assert h1 == h2
 
+    def test_large_int_preserves_precision(self):
+        """Large integers (>2^53) hash deterministically without precision loss."""
+        large_int = 2**63
+        ops = [{"gate": "custom", "qubits": [0], "params": {"n": large_int}}]
+
+        h1 = hash_parametric(ops, 1, 0)
+        h2 = hash_parametric(ops, 1, 0)
+
+        # Same large int => same hash
+        assert h1 == h2
+
+        # Different large ints => different hashes
+        ops_different = [{"gate": "custom", "qubits": [0], "params": {"n": 2**63 + 1}}]
+        h3 = hash_parametric(ops_different, 1, 0)
+        assert h1 != h3
+
+    def test_int_float_distinguished(self):
+        """Integer 1 and float 1.0 produce different hashes."""
+        ops_int = [{"gate": "rz", "qubits": [0], "params": {"t": 1}}]
+        ops_float = [{"gate": "rz", "qubits": [0], "params": {"t": 1.0}}]
+
+        h_int = hash_parametric(ops_int, 1, 0)
+        h_float = hash_parametric(ops_float, 1, 0)
+
+        assert h_int != h_float
+
 
 class TestExtractFromRefs:
     """Test circuit extraction from artifact refs (UEC envelope flow)."""

--- a/packages/devqubit-engine/tests/test_schema.py
+++ b/packages/devqubit-engine/tests/test_schema.py
@@ -146,7 +146,7 @@ class TestEnvelopeValidation:
 
     def test_invalid_result_status_fails(self, valid_envelope):
         """Invalid result status fails."""
-        valid_envelope["result"]["status"] = "running"  # not in enum
+        valid_envelope["result"]["status"] = "unknown_status"  # not in enum
 
         with pytest.raises(ValueError, match="status"):
             validate_envelope(valid_envelope)

--- a/packages/devqubit-engine/tests/test_tracking.py
+++ b/packages/devqubit-engine/tests/test_tracking.py
@@ -94,18 +94,6 @@ class TestLogging:
         assert series[0]["value"] == 1.0
         assert series[2]["value"] == 0.2
 
-    def test_compile_execute_config(self, store, registry, config):
-        """Log transpiler and execution configuration."""
-        with track(project="config", config=config) as run:
-            run.log_compile({"optimization_level": 3, "routing_method": "sabre"})
-            run.log_execute({"shots": 4000, "resilience_level": 1})
-            run_id = run.run_id
-
-        loaded = registry.load(run_id)
-
-        assert loaded.record["compile"]["optimization_level"] == 3
-        assert loaded.record["execute"]["shots"] == 4000
-
 
 class TestArtifactLogging:
     """Tests for artifact logging methods."""

--- a/packages/devqubit-pennylane/src/devqubit_pennylane/results.py
+++ b/packages/devqubit-pennylane/src/devqubit_pennylane/results.py
@@ -173,8 +173,11 @@ def _sample_to_bitstring(sample: Any) -> str:
 
     except Exception as e:
         logger.debug("Failed to convert sample to bitstring: %s", e)
-        # Last resort: hash for uniqueness
-        return f"sample_{hash(str(sample)) % 10000:04d}"
+        # Use deterministic SHA256 hash instead of Python's hash()
+        import hashlib
+
+        digest = hashlib.sha256(str(sample).encode("utf-8")).hexdigest()[:8]
+        return f"sample_{digest}"
 
 
 def _extract_expectation_values(

--- a/packages/devqubit-qiskit-runtime/tests/test_qiskit_runtime_transpilation.py
+++ b/packages/devqubit-qiskit-runtime/tests/test_qiskit_runtime_transpilation.py
@@ -14,7 +14,7 @@ from devqubit_qiskit_runtime.adapter import QiskitRuntimeAdapter
 from devqubit_qiskit_runtime.transpilation import (
     TranspilationConfig,
     TranspilationOptions,
-    circuit_looks_isa,
+    circuit_looks_isa_simple,
     prepare_pubs_for_primitive,
 )
 from qiskit import QuantumCircuit
@@ -159,26 +159,26 @@ class TestCircuitLooksIsa:
         elif "ecr" in op_names:
             qc.ecr(0, 1)
 
-        assert circuit_looks_isa(qc, real_target, strict=False) is True
+        assert circuit_looks_isa_simple(qc, real_target, strict=False) is True
 
     def test_non_isa_circuit_fails(self, real_target, non_isa_circuit):
         """Non-ISA circuit (H gate) fails check with real target."""
-        assert circuit_looks_isa(non_isa_circuit, real_target) is False
+        assert circuit_looks_isa_simple(non_isa_circuit, real_target) is False
 
     def test_no_target_returns_true(self, non_isa_circuit):
         """Returns True if no target provided (can't check)."""
-        assert circuit_looks_isa(non_isa_circuit, None) is True
+        assert circuit_looks_isa_simple(non_isa_circuit, None) is True
 
     def test_empty_circuit_is_isa(self, real_target):
         """Empty circuit is ISA compatible."""
         qc = QuantumCircuit(2)
-        assert circuit_looks_isa(qc, real_target) is True
+        assert circuit_looks_isa_simple(qc, real_target) is True
 
     def test_barrier_only_is_isa(self, real_target):
         """Circuit with only barriers is ISA compatible."""
         qc = QuantumCircuit(2)
         qc.barrier()
-        assert circuit_looks_isa(qc, real_target) is True
+        assert circuit_looks_isa_simple(qc, real_target) is True
 
 
 # =============================================================================

--- a/packages/devqubit-qiskit/src/devqubit_qiskit/circuits.py
+++ b/packages/devqubit-qiskit/src/devqubit_qiskit/circuits.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from devqubit_engine.circuit.hashing import hash_circuit_pair
+from devqubit_engine.circuit.hashing import encode_value, hash_circuit_pair
 from devqubit_engine.circuit.models import CircuitFormat
 from devqubit_engine.tracking.run import Run
 from devqubit_engine.uec.models.program import ProgramArtifact, ProgramRole
@@ -390,7 +390,6 @@ def _compute_binds_digest(
     """
     import hashlib
     import json
-    import struct
 
     if not parameter_binds:
         return None
@@ -408,21 +407,8 @@ def _compute_binds_digest(
             # Extract parameter name
             param_name = str(getattr(param, "name", param))
 
-            # Encode value deterministically (IEEE-754 hex for floats)
-            if value is None:
-                encoded = "__none__"
-            elif isinstance(value, float):
-                # Normalize -0.0 to 0.0
-                if value == 0.0:
-                    value = 0.0
-                encoded = struct.pack(">d", value).hex()
-            elif isinstance(value, int):
-                encoded = f"i:{value}"
-            else:
-                try:
-                    encoded = struct.pack(">d", float(value)).hex()
-                except (TypeError, ValueError):
-                    encoded = str(value)[:50]
+            # Encode value deterministically using engine function
+            encoded = encode_value(value)
 
             sorted_items.append((param_name, encoded))
 

--- a/packages/devqubit-qiskit/tests/test_qiskit_adapter.py
+++ b/packages/devqubit-qiskit/tests/test_qiskit_adapter.py
@@ -72,7 +72,10 @@ class TestQiskitAdapterInterface:
         assert adapter.supports_executor(QuantumCircuit(2)) is False
 
     def test_wrap_executor_returns_tracked_backend(
-        self, store, registry, aer_simulator
+        self,
+        store,
+        registry,
+        aer_simulator,
     ):
         """Wrapping returns a TrackedBackend."""
         with track(project="test", store=store, registry=registry) as run:
@@ -90,7 +93,11 @@ class TestTrackedBackendExecution:
     """Tests for backend wrapping and execution."""
 
     def test_run_returns_tracked_job(
-        self, bell_circuit, aer_simulator, store, registry
+        self,
+        bell_circuit,
+        aer_simulator,
+        store,
+        registry,
     ):
         """run() returns a TrackedJob with results."""
         with track(project="test", store=store, registry=registry) as run:
@@ -102,7 +109,11 @@ class TestTrackedBackendExecution:
             assert sum(counts.values()) == 100
 
     def test_bell_state_correlated_results(
-        self, bell_circuit, aer_simulator, store, registry
+        self,
+        bell_circuit,
+        aer_simulator,
+        store,
+        registry,
     ):
         """Bell state produces correlated 00/11 outcomes."""
         with track(project="test", store=store, registry=registry) as run:
@@ -215,7 +226,11 @@ class TestUECEnvelopeStructure:
         assert "result" in envelope
 
     def test_envelope_device_section(
-        self, bell_circuit, aer_simulator, store, registry
+        self,
+        bell_circuit,
+        aer_simulator,
+        store,
+        registry,
     ):
         """Envelope device section has required fields."""
         with track(project="test", store=store, registry=registry) as run:
@@ -229,7 +244,11 @@ class TestUECEnvelopeStructure:
         assert "captured_at" in device
 
     def test_envelope_program_section(
-        self, bell_circuit, aer_simulator, store, registry
+        self,
+        bell_circuit,
+        aer_simulator,
+        store,
+        registry,
     ):
         """Envelope program section has circuit info."""
         with track(project="test", store=store, registry=registry) as run:
@@ -247,7 +266,10 @@ class TestBatchQASM3Artifacts:
     """Multi-circuit batches produce QASM3 artifact per circuit."""
 
     def test_batch_3_circuits_produces_3_qasm3_refs(
-        self, aer_simulator, store, registry
+        self,
+        aer_simulator,
+        store,
+        registry,
     ):
         """Batch of 3 circuits should produce 3 QASM3 artifacts."""
         circuits = []
@@ -395,7 +417,11 @@ class TestIdempotentResultLogging:
     """job.result() called twice should not duplicate artifacts."""
 
     def test_result_twice_no_duplicates(
-        self, bell_circuit, aer_simulator, store, registry
+        self,
+        bell_circuit,
+        aer_simulator,
+        store,
+        registry,
     ):
         """job.result() called twice creates only 1 envelope."""
         with track(project="test", store=store, registry=registry) as run:
@@ -443,10 +469,13 @@ class TestPendingEnvelopeLifecycle:
     """Tests for envelope lifecycle - pending on submit, finalized on result."""
 
     def test_pending_envelope_logged_on_submit(
-        self, bell_circuit, aer_simulator, store, registry
+        self,
+        bell_circuit,
+        aer_simulator,
+        store,
+        registry,
     ):
         """Pending envelope is logged when job is submitted (before .result())."""
-
         with track(project="test", store=store, registry=registry) as run:
             backend = run.wrap(aer_simulator)
             _ = backend.run(bell_circuit, shots=100)
@@ -458,7 +487,11 @@ class TestPendingEnvelopeLifecycle:
         assert envelope_count >= 1
 
     def test_completed_envelope_after_result(
-        self, bell_circuit, aer_simulator, store, registry
+        self,
+        bell_circuit,
+        aer_simulator,
+        store,
+        registry,
     ):
         """After .result(), envelope status is completed."""
         with track(project="test", store=store, registry=registry) as run:
@@ -481,10 +514,8 @@ class TestPendingEnvelopeLifecycle:
 class TestParameterBindsTracking:
     """Tests for parameter_binds affecting parametric_hash."""
 
-    def test_different_binds_different_parametric_hash(
-        self, aer_simulator, store, registry
-    ):
-        """Different parameter_binds produce different parametric hashes."""
+    def test_different_bound_params(self, aer_simulator, store, registry):
+        """Different bound parameter values produce different parametric hashes."""
         from qiskit.circuit import Parameter
 
         theta = Parameter("theta")
@@ -492,21 +523,22 @@ class TestParameterBindsTracking:
         qc.rx(theta, 0)
         qc.measure_all()
 
-        binds1 = [{theta: 0.5}]
-        binds2 = [{theta: 1.5}]
+        # Bind parameters before execution (Aer-compatible approach)
+        qc1 = qc.assign_parameters({theta: 0.5})
+        qc2 = qc.assign_parameters({theta: 1.5})
 
         with track(project="test", store=store, registry=registry) as run1:
             backend1 = run1.wrap(aer_simulator)
-            backend1.run(qc, shots=100, parameter_binds=binds1).result()
+            backend1.run(qc1, shots=100).result()
 
         with track(project="test", store=store, registry=registry) as run2:
             backend2 = run2.wrap(aer_simulator)
-            backend2.run(qc, shots=100, parameter_binds=binds2).result()
+            backend2.run(qc2, shots=100).result()
 
         _, env1 = _load_envelope(run1.run_id, store, registry)
         _, env2 = _load_envelope(run2.run_id, store, registry)
 
         # Structural hash should be the same (same circuit structure)
         assert env1["program"]["structural_hash"] == env2["program"]["structural_hash"]
-        # Parametric hash should differ (different bind values)
+        # Parametric hash should differ (different bound values)
         assert env1["program"]["parametric_hash"] != env2["program"]["parametric_hash"]

--- a/packages/devqubit-qiskit/tests/test_qiskit_circuits.py
+++ b/packages/devqubit-qiskit/tests/test_qiskit_circuits.py
@@ -232,6 +232,59 @@ class TestBatchAndFormat:
 
 
 # =============================================================================
+# Parameter Binds Hashing Tests
+# =============================================================================
+
+
+class TestParameterBindsHashing:
+    """Tests for parameter_binds incorporation into parametric hash."""
+
+    def test_different_binds_different_parametric_hash(self):
+        """Different parameter_binds produce different parametric hashes."""
+        theta = Parameter("theta")
+        qc = QuantumCircuit(1)
+        qc.rx(theta, 0)
+        qc.measure_all()
+
+        binds1 = [{theta: 0.5}]
+        binds2 = [{theta: 1.5}]
+
+        structural1, parametric1 = compute_circuit_hashes([qc], binds1)
+        structural2, parametric2 = compute_circuit_hashes([qc], binds2)
+
+        assert structural1 == structural2  # Same structure
+        assert parametric1 != parametric2  # Different binds
+
+    def test_same_binds_same_parametric_hash(self):
+        """Same parameter_binds produce same parametric hash."""
+        theta = Parameter("theta")
+        qc = QuantumCircuit(1)
+        qc.rx(theta, 0)
+        qc.measure_all()
+
+        binds = [{theta: 0.5}]
+
+        _, parametric1 = compute_circuit_hashes([qc], binds)
+        _, parametric2 = compute_circuit_hashes([qc], binds)
+
+        assert parametric1 == parametric2
+
+    def test_no_binds_uses_circuit_params(self):
+        """Without parameter_binds, hash uses circuit's bound values."""
+        theta = Parameter("theta")
+        qc = QuantumCircuit(1)
+        qc.rx(theta, 0)
+
+        bound1 = qc.assign_parameters({theta: 0.5})
+        bound2 = qc.assign_parameters({theta: 1.5})
+
+        _, parametric1 = compute_circuit_hashes([bound1], None)
+        _, parametric2 = compute_circuit_hashes([bound2], None)
+
+        assert parametric1 != parametric2
+
+
+# =============================================================================
 # UEC Hashing Contract Tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary
This PR makes tracking UEC-first by computing fingerprints from the ExecutionEnvelope instead of artifacts/records, ensuring stable, semantically correct run identity. It also tightens envelope resolution and improves run finalization behavior so adapter runs consistently produce valid UEC envelopes and tracking stays deterministic and robust.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Refactor (no user-facing change)
- [ ] Docs only
- [ ] CI/build tooling
- [ ] Breaking change

## Related issues / context
Link issues, discussions, or prior PRs:
- Closes #

## Changelog (user-facing only)
- [ ] I added a towncrier fragment in `changelog.d/` (skip for internal-only changes)

## Checklist
- [x] I ran lint locally (`uv run pre-commit run --all-files`)
- [x] I ran tests locally (`uv run pytest`)
- [x] I added/updated tests for behavior changes
- [ ] I updated docs/README/examples if needed
- [ ] If I changed dependencies, I updated `uv.lock` (`uv lock`) and committed it
- [x] I considered backward compatibility and security impact

## Notes for reviewers
- Fingerprints now derive from UEC envelope fields (program/device/intent) to avoid drift from volatile metadata (timestamps/job IDs) and to align with adapter-logged envelopes.
- Envelope resolution is now the single source of truth for tracking (manual runs may synthesize an envelope; adapter runs require a valid one).
