### PR TITLE
refactor(compare): compare module is based fully on envelope

### DIFF
--- a/changelog.d/29.fix.md
+++ b/changelog.d/29.fix.md
@@ -1,0 +1,1 @@
+Fixed critical bugs in compare/ module: item_index="all" now correctly returns counts from the worst TVD item, tvd_max threshold is now a hard limit when combined with noise_factor, and runs without program artifacts are correctly identified as identical.

--- a/packages/devqubit-engine/src/devqubit_engine/compare/_formatting.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/_formatting.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 devqubit
+
+"""
+Text formatting utilities for comparison results.
+
+This module provides human-readable text formatting for comparison and
+verification results. The formatting is separated from result dataclasses
+to keep them focused on data representation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from devqubit_engine.compare.types import FormatOptions
+
+
+if TYPE_CHECKING:
+    from devqubit_engine.compare.results import ComparisonResult, VerifyResult
+
+
+def _format_header(title: str, width: int = 70, char: str = "=") -> list[str]:
+    """Format a section header."""
+    return [char * width, title, char * width]
+
+
+def _format_change(key: str, change: dict[str, Any]) -> str:
+    """Format a single parameter/metric change with percentage."""
+    val_a = change.get("a")
+    val_b = change.get("b")
+
+    pct_str = ""
+    if isinstance(val_a, (int, float)) and isinstance(val_b, (int, float)):
+        if val_a != 0:
+            pct = ((val_b - val_a) / abs(val_a)) * 100
+            sign = "+" if pct > 0 else ""
+            pct_str = f" ({sign}{pct:.1f}%)"
+
+    return f"    {key}: {val_a} -> {val_b}{pct_str}"
+
+
+def _format_dict_changes(
+    diff: dict[str, Any],
+    opts: FormatOptions,
+    label_changed: str = "Changed",
+    label_removed: str = "Only in baseline",
+    label_added: str = "Only in candidate",
+) -> list[str]:
+    """Format dictionary comparison changes."""
+    lines: list[str] = []
+    max_changes = opts.max_param_changes
+
+    changed = diff.get("changed", {})
+    added = diff.get("added", {})
+    removed = diff.get("removed", {})
+
+    if changed:
+        lines.append(f"  {label_changed}:")
+        for i, (k, v) in enumerate(changed.items()):
+            if i >= max_changes:
+                lines.append(f"    ... and {len(changed) - i} more")
+                break
+            lines.append(_format_change(k, v))
+
+    if removed:
+        lines.append(f"  {label_removed}:")
+        for i, (k, v) in enumerate(removed.items()):
+            if i >= max_changes:
+                lines.append(f"    ... and {len(removed) - i} more")
+                break
+            lines.append(f"    {k}: {v}")
+
+    if added:
+        lines.append(f"  {label_added}:")
+        for i, (k, v) in enumerate(added.items()):
+            if i >= max_changes:
+                lines.append(f"    ... and {len(added) - i} more")
+                break
+            lines.append(f"    {k}: {v}")
+
+    return lines
+
+
+def _format_circuit_diff(circuit_diff, opts: FormatOptions) -> list[str]:
+    """Format circuit diff changes."""
+    lines: list[str] = []
+
+    if circuit_diff.changes:
+        if isinstance(circuit_diff.changes, dict):
+            for i, (key, change) in enumerate(circuit_diff.changes.items()):
+                if i >= opts.max_circuit_changes:
+                    lines.append(f"    ... and {len(circuit_diff.changes) - i} more")
+                    break
+                lines.append(f"    {key}: {change.get('a')} -> {change.get('b')}")
+        else:
+            for i, change in enumerate(circuit_diff.changes):
+                if i >= opts.max_circuit_changes:
+                    lines.append(f"    ... and {len(circuit_diff.changes) - i} more")
+                    break
+                lines.append(f"    {change}")
+
+    return lines
+
+
+def _format_drift_metrics(drift_result, opts: FormatOptions) -> list[str]:
+    """Format drift metrics."""
+    lines: list[str] = []
+
+    for i, m in enumerate(drift_result.top_drifts):
+        if i >= opts.max_drifts:
+            lines.append(f"    ... and {len(drift_result.top_drifts) - i} more")
+            break
+        pct = f"{m.percent_change:+.1f}%" if m.percent_change else "N/A"
+        lines.append(f"    {m.metric}: {m.value_a} -> {m.value_b} ({pct})")
+
+    return lines
+
+
+def format_comparison_result(
+    result: ComparisonResult,
+    opts: FormatOptions | None = None,
+) -> str:
+    """
+    Format ComparisonResult as human-readable text report.
+
+    Parameters
+    ----------
+    result : ComparisonResult
+        Comparison result to format.
+    opts : FormatOptions, optional
+        Formatting options.
+
+    Returns
+    -------
+    str
+        Formatted text report.
+    """
+    if opts is None:
+        opts = FormatOptions()
+
+    lines = _format_header("RUN COMPARISON", opts.width)
+    lines.extend(
+        [
+            f"Baseline:  {result.run_id_a}",
+            f"Candidate: {result.run_id_b}",
+            "",
+            f"Overall: {'✓ IDENTICAL' if result.identical else '✗ DIFFER'}",
+        ]
+    )
+
+    # Metadata section
+    if result.metadata:
+        lines.extend(["", "-" * opts.width, "Metadata", "-" * opts.width])
+
+        project_match = result.metadata.get("project_match", True)
+        if project_match:
+            lines.append("  project: ✓")
+        else:
+            a = result.metadata.get("project_a", "?")
+            b = result.metadata.get("project_b", "?")
+            lines.append("  project: ✗")
+            lines.append(f"    {a} -> {b}")
+
+        backend_match = result.metadata.get("backend_match", True)
+        if backend_match:
+            lines.append("  backend: ✓")
+        else:
+            a = result.metadata.get("backend_a", "?")
+            b = result.metadata.get("backend_b", "?")
+            lines.append("  backend: ✗")
+            lines.append(f"    {a} -> {b}")
+
+    # Program section
+    lines.extend(["", "-" * opts.width, "Program", "-" * opts.width])
+    if result.program.exact_match:
+        prog_status = "✓ Match (exact)"
+    elif result.program.structural_match:
+        prog_status = "✓ Match (structural)"
+    else:
+        prog_status = "✗ Differ"
+    lines.append(f"  {prog_status}")
+
+    # Parameters section
+    if result.params:
+        lines.extend(["", "-" * opts.width, "Parameters", "-" * opts.width])
+        if result.params.get("match", False):
+            lines.append("  ✓ Match")
+        else:
+            lines.extend(_format_dict_changes(result.params, opts))
+
+    # Metrics section
+    if result.metrics:
+        lines.extend(["", "-" * opts.width, "Metrics", "-" * opts.width])
+        if result.metrics.get("match", True):
+            lines.append("  ✓ Match")
+        else:
+            lines.extend(_format_dict_changes(result.metrics, opts))
+
+    # Device drift section
+    if result.device_drift and result.device_drift.has_calibration_data:
+        lines.extend(["", "-" * opts.width, "Device Calibration", "-" * opts.width])
+        if result.device_drift.calibration_time_changed:
+            lines.append("  Calibration times differ:")
+            lines.append(f"    Baseline:  {result.device_drift.calibration_time_a}")
+            lines.append(f"    Candidate: {result.device_drift.calibration_time_b}")
+        if result.device_drift.significant_drift:
+            lines.append("  ✗ Significant drift detected:")
+            lines.extend(_format_drift_metrics(result.device_drift, opts))
+        else:
+            lines.append("  ✓ Drift within thresholds")
+
+    # Results section (TVD + noise)
+    if result.tvd is not None or result.noise_context:
+        lines.extend(["", "-" * opts.width, "Results", "-" * opts.width])
+        if result.tvd is not None:
+            lines.append(f"  TVD: {result.tvd:.6f}")
+        if result.noise_context:
+            lines.append(f"  Expected noise: {result.noise_context.expected_noise:.6f}")
+            lines.append(f"  Noise ratio: {result.noise_context.noise_ratio:.2f}x")
+            lines.append(f"  Interpretation: {result.noise_context.interpretation()}")
+
+    # Circuit section
+    lines.extend(["", "-" * opts.width, "Circuit", "-" * opts.width])
+    if result.circuit_diff is None:
+        lines.append("  N/A (not captured)")
+    elif result.circuit_diff.match:
+        lines.append("  ✓ Match")
+    else:
+        lines.append("  ✗ Differ:")
+        lines.extend(_format_circuit_diff(result.circuit_diff, opts))
+
+    # Warnings section
+    if result.warnings:
+        lines.extend(["", "-" * opts.width, "Warnings", "-" * opts.width])
+        for w in result.warnings:
+            lines.append(f"  ! {w}")
+
+    lines.extend(["", "=" * opts.width])
+    return "\n".join(lines)
+
+
+def format_verify_result(
+    result: VerifyResult,
+    opts: FormatOptions | None = None,
+) -> str:
+    """
+    Format VerifyResult as human-readable text report.
+
+    Parameters
+    ----------
+    result : VerifyResult
+        Verification result to format.
+    opts : FormatOptions, optional
+        Formatting options.
+
+    Returns
+    -------
+    str
+        Formatted text report.
+    """
+    if opts is None:
+        opts = FormatOptions()
+
+    lines = _format_header("VERIFICATION RESULT", opts.width)
+    lines.extend(
+        [
+            f"Baseline:  {result.baseline_run_id or 'N/A'}",
+            f"Candidate: {result.candidate_run_id}",
+            f"Duration:  {result.duration_ms:.1f}ms",
+            "",
+            f"Status: {'✓ PASSED' if result.ok else '✗ FAILED'}",
+        ]
+    )
+
+    # Failures section
+    if not result.ok and result.failures:
+        lines.extend(["", "-" * opts.width, "Failures", "-" * opts.width])
+        for failure in result.failures:
+            lines.append(f"  ✗ {failure}")
+
+    # Results section
+    if result.comparison:
+        comp = result.comparison
+        if comp.tvd is not None or comp.noise_context:
+            lines.extend(["", "-" * opts.width, "Results", "-" * opts.width])
+            if comp.tvd is not None:
+                lines.append(f"  TVD: {comp.tvd:.6f}")
+            if comp.noise_context:
+                lines.append(
+                    f"  Expected noise: {comp.noise_context.expected_noise:.6f}"
+                )
+                lines.append(f"  Noise ratio: {comp.noise_context.noise_ratio:.2f}x")
+                lines.append(f"  Interpretation: {comp.noise_context.interpretation()}")
+
+        # Circuit section (only if differs)
+        if comp.circuit_diff and not comp.circuit_diff.match:
+            lines.extend(["", "-" * opts.width, "Circuit", "-" * opts.width])
+            lines.append("  ✗ Differ:")
+            lines.extend(_format_circuit_diff(comp.circuit_diff, opts))
+
+        # Device drift section (only if significant)
+        if comp.device_drift and comp.device_drift.significant_drift:
+            lines.extend(["", "-" * opts.width, "Device Calibration", "-" * opts.width])
+            lines.append("  ✗ Significant drift detected:")
+            lines.extend(_format_drift_metrics(comp.device_drift, opts))
+
+    # Verdict section
+    if result.verdict:
+        lines.extend(["", "-" * opts.width, "Root Cause Analysis", "-" * opts.width])
+        lines.append(f"  Category: {result.verdict.category.value}")
+        lines.append(f"  Summary: {result.verdict.summary}")
+        lines.append(f"  Action: {result.verdict.action}")
+        if result.verdict.contributing_factors:
+            lines.append(f"  Factors: {', '.join(result.verdict.contributing_factors)}")
+
+    lines.extend(["", "=" * opts.width])
+    return "\n".join(lines)

--- a/packages/devqubit-engine/src/devqubit_engine/compare/context.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/context.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 devqubit
+
+"""
+Execution context and envelope extraction utilities.
+
+This module provides the RunContext abstraction and helper functions for
+extracting data from ExecutionEnvelopes. These are the building blocks
+for comparison, verification, and verdict operations.
+
+The extraction functions are part of the public API and are used by
+both the diff and verdict modules.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from devqubit_engine.storage.types import ObjectStoreProtocol
+    from devqubit_engine.uec.models.device import DeviceSnapshot
+    from devqubit_engine.uec.models.envelope import ExecutionEnvelope
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class RunContext:
+    """
+    Execution context for comparison operations.
+
+    Encapsulates all data needed for comparing a single run: the resolved
+    envelope and the object store for artifact access. This is the primary
+    input type for core comparison functions.
+
+    Parameters
+    ----------
+    run_id : str
+        Unique run identifier.
+    envelope : ExecutionEnvelope
+        Resolved execution envelope containing all run data.
+    store : ObjectStoreProtocol
+        Object store for loading artifacts referenced in the envelope.
+
+    Notes
+    -----
+    RunContext is created by IO layer functions (diff, verify_against_baseline)
+    and passed to core comparison functions (diff_contexts, verify_contexts).
+    This separation ensures the core comparison logic is pure and testable.
+    """
+
+    run_id: str
+    envelope: ExecutionEnvelope
+    store: ObjectStoreProtocol
+
+
+# =============================================================================
+# Metadata extraction
+# =============================================================================
+
+
+def extract_devqubit_metadata(envelope: ExecutionEnvelope) -> dict[str, Any]:
+    """
+    Extract devqubit namespace from envelope metadata.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+
+    Returns
+    -------
+    dict
+        The devqubit metadata namespace, or empty dict if not present.
+    """
+    devqubit = envelope.metadata.get("devqubit")
+    if devqubit is None:
+        return {}
+    if not isinstance(devqubit, dict):
+        logger.warning(
+            "envelope.metadata.devqubit is not a dict (got %s), treating as empty",
+            type(devqubit).__name__,
+        )
+        return {}
+    return devqubit
+
+
+def extract_params(envelope: ExecutionEnvelope) -> dict[str, Any]:
+    """
+    Extract parameters from envelope metadata.devqubit namespace.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+
+    Returns
+    -------
+    dict
+        Parameters dictionary, or empty dict if not present.
+    """
+    devqubit = extract_devqubit_metadata(envelope)
+    return devqubit.get("params", {}) or {}
+
+
+def extract_metrics(envelope: ExecutionEnvelope) -> dict[str, Any]:
+    """
+    Extract metrics from envelope metadata.devqubit namespace.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+
+    Returns
+    -------
+    dict
+        Metrics dictionary, or empty dict if not present.
+    """
+    devqubit = extract_devqubit_metadata(envelope)
+    return devqubit.get("metrics", {}) or {}
+
+
+def extract_project(envelope: ExecutionEnvelope) -> str | None:
+    """
+    Extract project name from envelope metadata.devqubit namespace.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+
+    Returns
+    -------
+    str or None
+        Project name if present.
+    """
+    devqubit = extract_devqubit_metadata(envelope)
+    return devqubit.get("project")
+
+
+def extract_fingerprint(envelope: ExecutionEnvelope) -> str | None:
+    """
+    Extract run fingerprint from envelope metadata.devqubit namespace.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+
+    Returns
+    -------
+    str or None
+        Run fingerprint if present.
+    """
+    devqubit = extract_devqubit_metadata(envelope)
+    fingerprints = devqubit.get("fingerprints", {}) or {}
+    return fingerprints.get("run")
+
+
+def extract_backend_name(envelope: ExecutionEnvelope) -> str | None:
+    """
+    Extract backend name from envelope device snapshot.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+
+    Returns
+    -------
+    str or None
+        Backend name if device snapshot present.
+    """
+    if envelope.device:
+        return envelope.device.backend_name
+    return None
+
+
+# =============================================================================
+# Result extraction
+# =============================================================================
+
+
+def get_counts_from_envelope(
+    envelope: ExecutionEnvelope,
+    item_index: int = 0,
+    *,
+    canonicalize: bool = True,
+    skip_failed: bool = True,
+) -> dict[str, int] | None:
+    """
+    Extract counts from envelope result item.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+    item_index : int, default=0
+        Index of the result item to extract counts from.
+    canonicalize : bool, default=True
+        Whether to canonicalize bitstrings to cbit0_right format.
+    skip_failed : bool, default=True
+        If True, skip items with success=False and return None for them.
+
+    Returns
+    -------
+    dict or None
+        Counts as {bitstring: count} in canonical format, or None if not
+        available.
+    """
+    from devqubit_engine.uec.models.result import canonicalize_bitstrings
+
+    if not envelope.result.items:
+        return None
+
+    if item_index >= len(envelope.result.items):
+        return None
+
+    item = envelope.result.items[item_index]
+
+    if skip_failed and item.success is False:
+        logger.debug("Skipping failed result item at index %d", item_index)
+        return None
+
+    if not item.counts:
+        return None
+
+    raw_counts = item.counts.get("counts")
+    if not isinstance(raw_counts, dict):
+        return None
+
+    if canonicalize:
+        format_info = item.counts.get("format", {})
+        bit_order = format_info.get("bit_order", "cbit0_right")
+        transformed = format_info.get("transformed", False)
+        canonical = canonicalize_bitstrings(
+            raw_counts,
+            bit_order=bit_order,
+            transformed=transformed,
+        )
+        return {k: int(v) for k, v in canonical.items()}
+    else:
+        return {str(k): int(v) for k, v in raw_counts.items()}
+
+
+def get_all_counts_from_envelope(
+    envelope: ExecutionEnvelope,
+    *,
+    canonicalize: bool = True,
+    skip_failed: bool = True,
+) -> list[tuple[int, dict[str, int]]]:
+    """
+    Extract counts from all result items in the envelope.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+    canonicalize : bool, default=True
+        Whether to canonicalize bitstrings.
+    skip_failed : bool, default=True
+        If True, skip items with success=False.
+
+    Returns
+    -------
+    list of tuple
+        List of (item_index, counts) tuples for each successful result item.
+        Empty list if no counts available.
+    """
+    results: list[tuple[int, dict[str, int]]] = []
+    skipped_count = 0
+
+    for idx in range(len(envelope.result.items)):
+        item = envelope.result.items[idx]
+
+        if skip_failed and item.success is False:
+            skipped_count += 1
+            continue
+
+        counts = get_counts_from_envelope(
+            envelope, idx, canonicalize=canonicalize, skip_failed=False
+        )
+        if counts is not None:
+            results.append((idx, counts))
+
+    if skipped_count > 0:
+        logger.debug(
+            "Skipped %d failed result items when extracting counts", skipped_count
+        )
+
+    return results
+
+
+# =============================================================================
+# Device and circuit extraction
+# =============================================================================
+
+
+def get_device_snapshot(envelope: ExecutionEnvelope) -> DeviceSnapshot | None:
+    """
+    Get device snapshot from envelope.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+
+    Returns
+    -------
+    DeviceSnapshot or None
+        Device snapshot if present.
+    """
+    return envelope.device
+
+
+def extract_circuit_summary(
+    envelope: ExecutionEnvelope,
+    store: ObjectStoreProtocol,
+    *,
+    which: str = "logical",
+):
+    """
+    Extract circuit summary from envelope.
+
+    Parameters
+    ----------
+    envelope : ExecutionEnvelope
+        Execution envelope.
+    store : ObjectStoreProtocol
+        Object store for loading artifacts.
+    which : str, default="logical"
+        Which circuit to extract: "logical" or "physical".
+
+    Returns
+    -------
+    CircuitSummary or None
+        Extracted circuit summary, or None if not found.
+    """
+    from devqubit_engine.circuit.extractors import extract_circuit_from_envelope
+    from devqubit_engine.circuit.summary import summarize_circuit_data
+
+    circuit_data = extract_circuit_from_envelope(envelope, store, which=which)
+
+    if circuit_data is not None:
+        try:
+            return summarize_circuit_data(circuit_data)
+        except Exception as e:
+            logger.debug("Failed to summarize circuit: %s", e)
+
+    return None

--- a/packages/devqubit-engine/src/devqubit_engine/compare/drift.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/drift.py
@@ -32,6 +32,10 @@ class DriftThresholds:
     When a metric changes by more than its threshold, it is flagged as
     significant drift.
 
+    Minimum absolute thresholds (min_abs_*) provide protection against
+    false positives when baseline values are small. A change must exceed
+    BOTH the relative threshold AND the absolute minimum to be flagged.
+
     Attributes
     ----------
     t1_us : float
@@ -42,12 +46,18 @@ class DriftThresholds:
         Threshold for readout error rate. Default is 0.20 (20%).
     q2_error : float
         Threshold for two-qubit gate error. Default is 0.20 (20%).
+    min_abs_readout_error : float
+        Minimum absolute change for readout error. Default is 0.003.
+    min_abs_q2_error : float
+        Minimum absolute change for 2Q gate error. Default is 0.001.
     """
 
     t1_us: float = 0.10
     t2_us: float = 0.10
     readout_error: float = 0.20
     q2_error: float = 0.20
+    min_abs_readout_error: float = 0.003
+    min_abs_q2_error: float = 0.001
 
     def get_threshold(self, metric: str) -> float | None:
         """
@@ -67,6 +77,25 @@ class DriftThresholds:
         key = metric.replace("median_", "").replace("2q_", "q2_")
         return getattr(self, key, None)
 
+    def get_min_abs(self, metric: str) -> float | None:
+        """
+        Get minimum absolute threshold for a metric name.
+
+        Parameters
+        ----------
+        metric : str
+            Metric name (e.g., "median_readout_error").
+
+        Returns
+        -------
+        float or None
+            Minimum absolute threshold, or None if not applicable.
+        """
+        # Map metric names to min_abs fields
+        key = metric.replace("median_", "").replace("2q_", "q2_")
+        min_abs_key = f"min_abs_{key}"
+        return getattr(self, min_abs_key, None)
+
     def to_dict(self) -> dict[str, float]:
         """
         Return thresholds as dictionary.
@@ -81,6 +110,8 @@ class DriftThresholds:
             "median_t2_us": self.t2_us,
             "median_readout_error": self.readout_error,
             "median_2q_error": self.q2_error,
+            "min_abs_readout_error": self.min_abs_readout_error,
+            "min_abs_q2_error": self.min_abs_q2_error,
         }
 
 
@@ -101,6 +132,7 @@ def _compute_metric_drift(
     val_a: float | None,
     val_b: float | None,
     threshold: float | None,
+    min_abs: float | None = None,
 ) -> MetricDrift:
     """
     Compute drift for a single metric.
@@ -114,7 +146,9 @@ def _compute_metric_drift(
     val_b : float or None
         Candidate value.
     threshold : float or None
-        Significance threshold.
+        Significance threshold (relative change).
+    min_abs : float or None
+        Minimum absolute change required (for error rate metrics).
 
     Returns
     -------
@@ -132,16 +166,26 @@ def _compute_metric_drift(
         return drift
 
     drift.delta = val_b - val_a
+    abs_delta = abs(drift.delta)
 
     if val_a != 0.0:
-        frac_change = abs(drift.delta / val_a)
+        frac_change = abs_delta / abs(val_a)
         drift.percent_change = frac_change * 100.0
         if threshold is not None:
-            drift.significant = frac_change > threshold
+            # Check relative threshold
+            exceeds_rel = frac_change > threshold
+            # Check minimum absolute threshold (if applicable)
+            exceeds_abs = min_abs is None or abs_delta > min_abs
+            # Both conditions must be met
+            drift.significant = exceeds_rel and exceeds_abs
     elif val_b != 0.0:
         # val_a is zero but val_b is not
         drift.percent_change = float("inf")
-        drift.significant = True
+        # For zero baseline, only check min_abs if available
+        if min_abs is not None:
+            drift.significant = abs_delta > min_abs
+        else:
+            drift.significant = True
 
     return drift
 
@@ -191,8 +235,9 @@ def compute_drift(
         val_a = getattr(cal_a, metric, None) if cal_a else None
         val_b = getattr(cal_b, metric, None) if cal_b else None
         threshold = thresholds.get_threshold(metric)
+        min_abs = thresholds.get_min_abs(metric)
 
-        drift = _compute_metric_drift(metric, val_a, val_b, threshold)
+        drift = _compute_metric_drift(metric, val_a, val_b, threshold, min_abs)
         result.metrics.append(drift)
 
         if drift.significant:

--- a/packages/devqubit-engine/src/devqubit_engine/compare/drift.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/drift.py
@@ -13,11 +13,14 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from devqubit_engine.compare.results import DriftResult, MetricDrift
-from devqubit_engine.uec.models.calibration import DeviceCalibration
-from devqubit_engine.uec.models.device import DeviceSnapshot
+
+
+if TYPE_CHECKING:
+    from devqubit_engine.uec.models.calibration import DeviceCalibration
+    from devqubit_engine.uec.models.device import DeviceSnapshot
 
 
 logger = logging.getLogger(__name__)
@@ -73,7 +76,6 @@ class DriftThresholds:
         float or None
             Threshold value, or None if metric not recognized.
         """
-        # Strip common prefixes
         key = metric.replace("median_", "").replace("2q_", "q2_")
         return getattr(self, key, None)
 
@@ -91,7 +93,6 @@ class DriftThresholds:
         float or None
             Minimum absolute threshold, or None if not applicable.
         """
-        # Map metric names to min_abs fields
         key = metric.replace("median_", "").replace("2q_", "q2_")
         min_abs_key = f"min_abs_{key}"
         return getattr(self, min_abs_key, None)
@@ -172,16 +173,11 @@ def _compute_metric_drift(
         frac_change = abs_delta / abs(val_a)
         drift.percent_change = frac_change * 100.0
         if threshold is not None:
-            # Check relative threshold
             exceeds_rel = frac_change > threshold
-            # Check minimum absolute threshold (if applicable)
             exceeds_abs = min_abs is None or abs_delta > min_abs
-            # Both conditions must be met
             drift.significant = exceeds_rel and exceeds_abs
     elif val_b != 0.0:
-        # val_a is zero but val_b is not
         drift.percent_change = float("inf")
-        # For zero baseline, only check min_abs if available
         if min_abs is not None:
             drift.significant = abs_delta > min_abs
         else:
@@ -283,6 +279,8 @@ def compare_calibrations(
     dict
         Drift analysis result as dictionary.
     """
+    from devqubit_engine.uec.models.device import DeviceSnapshot
+
     snapshot_a = DeviceSnapshot(
         captured_at="",
         backend_name="",

--- a/packages/devqubit-engine/src/devqubit_engine/compare/results.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/results.py
@@ -296,6 +296,7 @@ class ProgramComparison:
 
     Captures exact (digest), structural (structural_hash), and parametric
     (parametric_hash) matching to support different verification policies.
+    Also includes executed hashes for physical circuits (post-compilation).
 
     Attributes
     ----------
@@ -317,6 +318,18 @@ class ProgramComparison:
         Parametric hash from baseline.
     parametric_hash_b : str or None
         Parametric hash from candidate.
+    executed_structural_hash_a : str or None
+        Executed structural hash from baseline (physical circuit).
+    executed_structural_hash_b : str or None
+        Executed structural hash from candidate (physical circuit).
+    executed_parametric_hash_a : str or None
+        Executed parametric hash from baseline (physical circuit).
+    executed_parametric_hash_b : str or None
+        Executed parametric hash from candidate (physical circuit).
+    executed_structural_match : bool
+        True if executed structural hashes match.
+    executed_parametric_match : bool
+        True if executed parametric hashes match.
     hash_available : bool
         True if program hashes were available for comparison.
 
@@ -325,6 +338,7 @@ class ProgramComparison:
     Hash semantics:
     - ``structural_hash``: Structure only. Same = same circuit template.
     - ``parametric_hash``: Structure + params. Same = identical execution.
+    - ``executed_*_hash``: Hashes for physical (compiled) circuits.
 
     For manual runs, hashes are unavailable and ``hash_available=False``.
     """
@@ -338,6 +352,12 @@ class ProgramComparison:
     circuit_hash_b: str | None = None
     parametric_hash_a: str | None = None
     parametric_hash_b: str | None = None
+    executed_structural_hash_a: str | None = None
+    executed_structural_hash_b: str | None = None
+    executed_parametric_hash_a: str | None = None
+    executed_parametric_hash_b: str | None = None
+    executed_structural_match: bool = False
+    executed_parametric_match: bool = False
     hash_available: bool = True
 
     @property
@@ -386,7 +406,7 @@ class ProgramComparison:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
-        return {
+        d: dict[str, Any] = {
             "exact_match": self.exact_match,
             "structural_match": self.structural_match,
             "parametric_match": self.parametric_match,
@@ -400,6 +420,16 @@ class ProgramComparison:
             "parametric_hash_a": self.parametric_hash_a,
             "parametric_hash_b": self.parametric_hash_b,
         }
+        # Include executed hashes if available
+        if self.executed_structural_hash_a or self.executed_structural_hash_b:
+            d["executed_structural_hash_a"] = self.executed_structural_hash_a
+            d["executed_structural_hash_b"] = self.executed_structural_hash_b
+            d["executed_structural_match"] = self.executed_structural_match
+        if self.executed_parametric_hash_a or self.executed_parametric_hash_b:
+            d["executed_parametric_hash_a"] = self.executed_parametric_hash_a
+            d["executed_parametric_hash_b"] = self.executed_parametric_hash_b
+            d["executed_parametric_match"] = self.executed_parametric_match
+        return d
 
     def __repr__(self) -> str:
         """Return string representation."""

--- a/packages/devqubit-engine/src/devqubit_engine/compare/results.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/results.py
@@ -12,95 +12,25 @@ by comparison and verification operations.
 from __future__ import annotations
 
 import json
-import logging
 from dataclasses import dataclass, field
-from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from devqubit_engine.circuit.summary import CircuitDiff
-from devqubit_engine.utils.distributions import NoiseContext
-
-
-logger = logging.getLogger(__name__)
-
-
-class ProgramMatchMode(str, Enum):
-    """
-    Program matching mode for verification.
-
-    Attributes
-    ----------
-    EXACT : str
-        Require artifact digest equality (strict reproducibility).
-        Use when you need byte-for-byte identical circuits.
-    STRUCTURAL : str
-        Require circuit_hash (structure) equality (variational-friendly).
-        Use for Variational Circuits where parameter values differ but structure is same.
-    EITHER : str
-        Pass if exact OR structural match (recommended default).
-        Detects true program changes without breaking variational workflows.
-    """
-
-    EXACT = "exact"
-    STRUCTURAL = "structural"
-    EITHER = "either"
+from devqubit_engine.compare.types import (
+    FormatOptions,
+    ProgramMatchMode,
+    ProgramMatchStatus,
+    VerdictCategory,
+)
 
 
-class VerdictCategory(str, Enum):
-    """
-    Root-cause categories for verification regression.
-
-    Attributes
-    ----------
-    PROGRAM_CHANGED : str
-        The quantum program (circuit) has changed.
-    COMPILER_CHANGED : str
-        Same circuit compiled differently (depth/2Q gates changed).
-    DEVICE_DRIFT : str
-        Device calibration has drifted significantly.
-    SHOT_NOISE : str
-        Difference is consistent with statistical sampling noise.
-    MIXED : str
-        Multiple contributing factors detected.
-    UNKNOWN : str
-        No clear root cause identified.
-    """
-
-    PROGRAM_CHANGED = "PROGRAM_CHANGED"
-    COMPILER_CHANGED = "COMPILER_CHANGED"
-    DEVICE_DRIFT = "DEVICE_DRIFT"
-    SHOT_NOISE = "SHOT_NOISE"
-    MIXED = "MIXED"
-    UNKNOWN = "UNKNOWN"
+if TYPE_CHECKING:
+    from devqubit_engine.circuit.summary import CircuitDiff
+    from devqubit_engine.utils.distributions import NoiseContext
 
 
-@dataclass
-class FormatOptions:
-    """
-    Formatting options for text reports.
-
-    Attributes
-    ----------
-    max_drifts : int
-        Maximum drift metrics to display. Default is 5.
-    max_circuit_changes : int
-        Maximum circuit changes to display. Default is 10.
-    max_param_changes : int
-        Maximum parameter changes to display. Default is 10.
-    max_metric_changes : int
-        Maximum metric changes to display. Default is 10.
-    show_evidence : bool
-        Show detailed evidence in verdicts. Default is True.
-    width : int
-        Line width for text output. Default is 70.
-    """
-
-    max_drifts: int = 5
-    max_circuit_changes: int = 10
-    max_param_changes: int = 10
-    max_metric_changes: int = 10
-    show_evidence: bool = True
-    width: int = 70
+# =============================================================================
+# Drift results
+# =============================================================================
 
 
 @dataclass
@@ -150,7 +80,6 @@ class MetricDrift:
         return d
 
     def __repr__(self) -> str:
-        """Return string representation."""
         sig = "!" if self.significant else ""
         return f"MetricDrift({self.metric}{sig}, {self.value_a} -> {self.value_b})"
 
@@ -217,11 +146,15 @@ class DriftResult:
         }
 
     def __repr__(self) -> str:
-        """Return string representation."""
         if not self.has_calibration_data:
             return "DriftResult(no_data)"
         status = "significant" if self.significant_drift else "within_threshold"
         return f"DriftResult({status}, {len(self.metrics)} metrics)"
+
+
+# =============================================================================
+# Verdict
+# =============================================================================
 
 
 @dataclass
@@ -260,33 +193,12 @@ class Verdict:
         }
 
     def __repr__(self) -> str:
-        """Return string representation."""
         return f"Verdict({self.category.value})"
 
 
-@dataclass
-class ProgramMatchStatus(str, Enum):
-    """
-    Detailed program match status.
-
-    Based on structural (structural_hash) and parametric (parametric_hash) comparison.
-
-    Attributes
-    ----------
-    FULL_MATCH : str
-        Both structural and parametric hashes match (identical execution).
-    STRUCTURAL_MATCH_PARAM_MISMATCH : str
-        Same circuit structure but different parameter values (VQE iteration).
-    STRUCTURAL_MISMATCH : str
-        Different circuit structure (different program).
-    HASH_UNAVAILABLE : str
-        Cannot determine - hashes not available (manual run).
-    """
-
-    FULL_MATCH = "FULL_MATCH"
-    STRUCTURAL_MATCH_PARAM_MISMATCH = "STRUCTURAL_MATCH_PARAM_MISMATCH"
-    STRUCTURAL_MISMATCH = "STRUCTURAL_MISMATCH"
-    HASH_UNAVAILABLE = "HASH_UNAVAILABLE"
+# =============================================================================
+# Program comparison
+# =============================================================================
 
 
 @dataclass
@@ -336,6 +248,7 @@ class ProgramComparison:
     Notes
     -----
     Hash semantics:
+
     - ``structural_hash``: Structure only. Same = same circuit template.
     - ``parametric_hash``: Structure + params. Same = identical execution.
     - ``executed_*_hash``: Hashes for physical (compiled) circuits.
@@ -420,7 +333,6 @@ class ProgramComparison:
             "parametric_hash_a": self.parametric_hash_a,
             "parametric_hash_b": self.parametric_hash_b,
         }
-        # Include executed hashes if available
         if self.executed_structural_hash_a or self.executed_structural_hash_b:
             d["executed_structural_hash_a"] = self.executed_structural_hash_a
             d["executed_structural_hash_b"] = self.executed_structural_hash_b
@@ -432,29 +344,12 @@ class ProgramComparison:
         return d
 
     def __repr__(self) -> str:
-        """Return string representation."""
         return f"ProgramComparison({self.status.value})"
 
 
-def _format_header(title: str, width: int = 70, char: str = "=") -> list[str]:
-    """Format a section header."""
-    return [char * width, title, char * width]
-
-
-def _format_change(key: str, change: dict[str, Any]) -> str:
-    """Format a single parameter/metric change."""
-    val_a = change.get("a")
-    val_b = change.get("b")
-
-    # Calculate percentage change for numeric values
-    pct_str = ""
-    if isinstance(val_a, (int, float)) and isinstance(val_b, (int, float)):
-        if val_a != 0:
-            pct = ((val_b - val_a) / abs(val_a)) * 100
-            sign = "+" if pct > 0 else ""
-            pct_str = f" ({sign}{pct:.1f}%)"
-
-    return f"    {key}: {val_a} -> {val_b}{pct_str}"
+# =============================================================================
+# Comparison result
+# =============================================================================
 
 
 @dataclass
@@ -535,11 +430,9 @@ class ComparisonResult:
         return self.program.matches(mode)
 
     def __str__(self) -> str:
-        """Return formatted text report."""
         return self.format()
 
     def __repr__(self) -> str:
-        """Return string representation."""
         status = "identical" if self.identical else "differ"
         return f"<ComparisonResult {self.run_id_a} vs {self.run_id_b}: {status}>"
 
@@ -557,183 +450,9 @@ class ComparisonResult:
         str
             Formatted text report.
         """
-        if opts is None:
-            opts = FormatOptions()
+        from devqubit_engine.compare._formatting import format_comparison_result
 
-        lines = _format_header("RUN COMPARISON", opts.width)
-        lines.extend(
-            [
-                f"Baseline:  {self.run_id_a}",
-                f"Candidate: {self.run_id_b}",
-                "",
-                f"Overall: {'✓ IDENTICAL' if self.identical else '✗ DIFFER'}",
-            ]
-        )
-
-        # Metadata section
-        if self.metadata:
-            lines.extend(["", "-" * opts.width, "Metadata", "-" * opts.width])
-
-            project_match = self.metadata.get("project_match", True)
-            if project_match:
-                lines.append("  project: ✓")
-            else:
-                a = self.metadata.get("project_a", "?")
-                b = self.metadata.get("project_b", "?")
-                lines.append("  project: ✗")
-                lines.append(f"    {a} -> {b}")
-
-            backend_match = self.metadata.get("backend_match", True)
-            if backend_match:
-                lines.append("  backend: ✓")
-            else:
-                a = self.metadata.get("backend_a", "?")
-                b = self.metadata.get("backend_b", "?")
-                lines.append("  backend: ✗")
-                lines.append(f"    {a} -> {b}")
-
-        # Program section
-        lines.extend(["", "-" * opts.width, "Program", "-" * opts.width])
-        if self.program.exact_match:
-            prog_status = "✓ Match (exact)"
-        elif self.program.structural_match:
-            prog_status = "✓ Match (structural)"
-        else:
-            prog_status = "✗ Differ"
-        lines.append(f"  {prog_status}")
-
-        # Parameters section
-        if self.params:
-            lines.extend(["", "-" * opts.width, "Parameters", "-" * opts.width])
-            if self.params.get("match", False):
-                lines.append("  ✓ Match")
-            else:
-                changed = self.params.get("changed", {})
-                added = self.params.get("added", {})
-                removed = self.params.get("removed", {})
-                if changed:
-                    lines.append("  Changed:")
-                    for i, (k, v) in enumerate(changed.items()):
-                        if i >= opts.max_param_changes:
-                            lines.append(f"    ... and {len(changed) - i} more")
-                            break
-                        lines.append(_format_change(k, v))
-                if removed:
-                    lines.append("  Only in baseline:")
-                    for i, (k, v) in enumerate(removed.items()):
-                        if i >= opts.max_param_changes:
-                            lines.append(f"    ... and {len(removed) - i} more")
-                            break
-                        lines.append(f"    {k}: {v}")
-                if added:
-                    lines.append("  Only in candidate:")
-                    for i, (k, v) in enumerate(added.items()):
-                        if i >= opts.max_param_changes:
-                            lines.append(f"    ... and {len(added) - i} more")
-                            break
-                        lines.append(f"    {k}: {v}")
-
-        # Metrics section
-        if self.metrics:
-            lines.extend(["", "-" * opts.width, "Metrics", "-" * opts.width])
-            if self.metrics.get("match", True):
-                lines.append("  ✓ Match")
-            else:
-                changed = self.metrics.get("changed", {})
-                added = self.metrics.get("added", {})
-                removed = self.metrics.get("removed", {})
-                if changed:
-                    lines.append("  Changed:")
-                    for i, (k, v) in enumerate(changed.items()):
-                        if i >= opts.max_metric_changes:
-                            lines.append(f"    ... and {len(changed) - i} more")
-                            break
-                        lines.append(_format_change(k, v))
-                if removed:
-                    lines.append("  Only in baseline:")
-                    for i, (k, v) in enumerate(removed.items()):
-                        if i >= opts.max_metric_changes:
-                            lines.append(f"    ... and {len(removed) - i} more")
-                            break
-                        lines.append(f"    {k}: {v}")
-                if added:
-                    lines.append("  Only in candidate:")
-                    for i, (k, v) in enumerate(added.items()):
-                        if i >= opts.max_metric_changes:
-                            lines.append(f"    ... and {len(added) - i} more")
-                            break
-                        lines.append(f"    {k}: {v}")
-
-        # Device drift section
-        if self.device_drift and self.device_drift.has_calibration_data:
-            lines.extend(["", "-" * opts.width, "Device Calibration", "-" * opts.width])
-            if self.device_drift.calibration_time_changed:
-                lines.append("  Calibration times differ:")
-                lines.append(f"    Baseline:  {self.device_drift.calibration_time_a}")
-                lines.append(f"    Candidate: {self.device_drift.calibration_time_b}")
-            if self.device_drift.significant_drift:
-                lines.append("  ✗ Significant drift detected:")
-                for i, m in enumerate(self.device_drift.top_drifts):
-                    if i >= opts.max_drifts:
-                        lines.append(
-                            f"    ... and {len(self.device_drift.top_drifts) - i} more"
-                        )
-                        break
-                    pct = f"{m.percent_change:+.1f}%" if m.percent_change else "N/A"
-                    lines.append(f"    {m.metric}: {m.value_a} -> {m.value_b} ({pct})")
-            else:
-                lines.append("  ✓ Drift within thresholds")
-
-        # Results section (TVD + noise)
-        if self.tvd is not None or self.noise_context:
-            lines.extend(["", "-" * opts.width, "Results", "-" * opts.width])
-            if self.tvd is not None:
-                lines.append(f"  TVD: {self.tvd:.6f}")
-            if self.noise_context:
-                lines.append(
-                    f"  Expected noise: {self.noise_context.expected_noise:.6f}"
-                )
-                lines.append(f"  Noise ratio: {self.noise_context.noise_ratio:.2f}x")
-                lines.append(f"  Interpretation: {self.noise_context.interpretation()}")
-
-        # Circuit section
-        lines.extend(["", "-" * opts.width, "Circuit", "-" * opts.width])
-        if self.circuit_diff is None:
-            lines.append("  N/A (not captured)")
-        elif self.circuit_diff.match:
-            lines.append("  ✓ Match")
-        else:
-            lines.append("  ✗ Differ:")
-            if self.circuit_diff.changes:
-                if isinstance(self.circuit_diff.changes, dict):
-                    for i, (key, change) in enumerate(
-                        self.circuit_diff.changes.items()
-                    ):
-                        if i >= opts.max_circuit_changes:
-                            lines.append(
-                                f"    ... and {len(self.circuit_diff.changes) - i} more"
-                            )
-                            break
-                        lines.append(
-                            f"    {key}: {change.get('a')} -> {change.get('b')}"
-                        )
-                else:
-                    for i, change in enumerate(self.circuit_diff.changes):
-                        if i >= opts.max_circuit_changes:
-                            lines.append(
-                                f"    ... and {len(self.circuit_diff.changes) - i} more"
-                            )
-                            break
-                        lines.append(f"    {change}")
-
-        # Warnings section
-        if self.warnings:
-            lines.extend(["", "-" * opts.width, "Warnings", "-" * opts.width])
-            for w in self.warnings:
-                lines.append(f"  ! {w}")
-
-        lines.extend(["", "=" * opts.width])
-        return "\n".join(lines)
+        return format_comparison_result(self, opts)
 
     def format_json(self, indent: int = 2) -> str:
         """Format as JSON string."""
@@ -802,6 +521,11 @@ class ComparisonResult:
         return result
 
 
+# =============================================================================
+# Verification result
+# =============================================================================
+
+
 @dataclass
 class VerifyResult:
     """
@@ -834,11 +558,9 @@ class VerifyResult:
     verdict: Verdict | None = None
 
     def __str__(self) -> str:
-        """Return formatted text report."""
         return self.format()
 
     def __repr__(self) -> str:
-        """Return string representation."""
         status = "PASS" if self.ok else "FAIL"
         return f"<VerifyResult {self.candidate_run_id}: {status}>"
 
@@ -856,100 +578,9 @@ class VerifyResult:
         str
             Formatted text report.
         """
-        if opts is None:
-            opts = FormatOptions()
+        from devqubit_engine.compare._formatting import format_verify_result
 
-        lines = _format_header("VERIFICATION RESULT", opts.width)
-        lines.extend(
-            [
-                f"Baseline:  {self.baseline_run_id or 'N/A'}",
-                f"Candidate: {self.candidate_run_id}",
-                f"Duration:  {self.duration_ms:.1f}ms",
-                "",
-                f"Status: {'✓ PASSED' if self.ok else '✗ FAILED'}",
-            ]
-        )
-
-        # Failures section
-        if not self.ok and self.failures:
-            lines.extend(["", "-" * opts.width, "Failures", "-" * opts.width])
-            for failure in self.failures:
-                lines.append(f"  ✗ {failure}")
-
-        # Results section
-        if self.comparison:
-            comp = self.comparison
-            if comp.tvd is not None or comp.noise_context:
-                lines.extend(["", "-" * opts.width, "Results", "-" * opts.width])
-                if comp.tvd is not None:
-                    lines.append(f"  TVD: {comp.tvd:.6f}")
-                if comp.noise_context:
-                    lines.append(
-                        f"  Expected noise: {comp.noise_context.expected_noise:.6f}"
-                    )
-                    lines.append(
-                        f"  Noise ratio: {comp.noise_context.noise_ratio:.2f}x"
-                    )
-                    lines.append(
-                        f"  Interpretation: {comp.noise_context.interpretation()}"
-                    )
-
-            # Circuit section (only if differs)
-            if comp.circuit_diff and not comp.circuit_diff.match:
-                lines.extend(["", "-" * opts.width, "Circuit", "-" * opts.width])
-                lines.append("  ✗ Differ:")
-                if comp.circuit_diff.changes:
-                    if isinstance(comp.circuit_diff.changes, dict):
-                        for i, (key, change) in enumerate(
-                            comp.circuit_diff.changes.items()
-                        ):
-                            if i >= opts.max_circuit_changes:
-                                lines.append(
-                                    f"    ... and {len(comp.circuit_diff.changes) - i} more"
-                                )
-                                break
-                            lines.append(
-                                f"    {key}: {change.get('a')} -> {change.get('b')}"
-                            )
-                    else:
-                        for i, change in enumerate(comp.circuit_diff.changes):
-                            if i >= opts.max_circuit_changes:
-                                lines.append(
-                                    f"    ... and {len(comp.circuit_diff.changes) - i} more"
-                                )
-                                break
-                            lines.append(f"    {change}")
-
-            # Device drift section (only if significant)
-            if comp.device_drift and comp.device_drift.significant_drift:
-                lines.extend(
-                    ["", "-" * opts.width, "Device Calibration", "-" * opts.width]
-                )
-                lines.append("  ✗ Significant drift detected:")
-                for i, m in enumerate(comp.device_drift.top_drifts):
-                    if i >= opts.max_drifts:
-                        lines.append(
-                            f"    ... and {len(comp.device_drift.top_drifts) - i} more"
-                        )
-                        break
-                    pct = f"{m.percent_change:+.1f}%" if m.percent_change else "N/A"
-                    lines.append(f"    {m.metric}: {m.value_a} -> {m.value_b} ({pct})")
-
-        # Verdict section
-        if self.verdict:
-            lines.extend(
-                ["", "-" * opts.width, "Root Cause Analysis", "-" * opts.width]
-            )
-            lines.append(f"  Category: {self.verdict.category.value}")
-            lines.append(f"  Summary: {self.verdict.summary}")
-            lines.append(f"  Action: {self.verdict.action}")
-            if self.verdict.contributing_factors:
-                lines.append(
-                    f"  Factors: {', '.join(self.verdict.contributing_factors)}"
-                )
-
-        lines.extend(["", "=" * opts.width])
-        return "\n".join(lines)
+        return format_verify_result(self, opts)
 
     def format_json(self, indent: int = 2) -> str:
         """Format as JSON string."""

--- a/packages/devqubit-engine/src/devqubit_engine/compare/types.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/types.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 devqubit
+
+"""
+Type definitions for comparison operations.
+
+This module contains enumerations and simple types used across the
+comparison subsystem. Keeping these separate avoids circular imports
+and provides a clean type vocabulary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ProgramMatchMode(str, Enum):
+    """
+    Program matching mode for verification.
+
+    Attributes
+    ----------
+    EXACT : str
+        Require artifact digest equality (strict reproducibility).
+        Use when you need byte-for-byte identical circuits.
+    STRUCTURAL : str
+        Require circuit_hash (structure) equality (variational-friendly).
+        Use for variational circuits where parameter values differ but
+        structure is same.
+    EITHER : str
+        Pass if exact OR structural match (recommended default).
+        Detects true program changes without breaking variational workflows.
+    """
+
+    EXACT = "exact"
+    STRUCTURAL = "structural"
+    EITHER = "either"
+
+
+class VerdictCategory(str, Enum):
+    """
+    Root-cause categories for verification regression.
+
+    Attributes
+    ----------
+    PROGRAM_CHANGED : str
+        The quantum program (circuit) has changed.
+    COMPILER_CHANGED : str
+        Same circuit compiled differently (depth/2Q gates changed).
+    DEVICE_DRIFT : str
+        Device calibration has drifted significantly.
+    SHOT_NOISE : str
+        Difference is consistent with statistical sampling noise.
+    MIXED : str
+        Multiple contributing factors detected.
+    UNKNOWN : str
+        No clear root cause identified.
+    """
+
+    PROGRAM_CHANGED = "PROGRAM_CHANGED"
+    COMPILER_CHANGED = "COMPILER_CHANGED"
+    DEVICE_DRIFT = "DEVICE_DRIFT"
+    SHOT_NOISE = "SHOT_NOISE"
+    MIXED = "MIXED"
+    UNKNOWN = "UNKNOWN"
+
+
+class ProgramMatchStatus(str, Enum):
+    """
+    Detailed program match status.
+
+    Based on structural (structural_hash) and parametric (parametric_hash)
+    comparison.
+
+    Attributes
+    ----------
+    FULL_MATCH : str
+        Both structural and parametric hashes match (identical execution).
+    STRUCTURAL_MATCH_PARAM_MISMATCH : str
+        Same circuit structure but different parameter values (VQE iteration).
+    STRUCTURAL_MISMATCH : str
+        Different circuit structure (different program).
+    HASH_UNAVAILABLE : str
+        Cannot determine - hashes not available (manual run).
+    """
+
+    FULL_MATCH = "FULL_MATCH"
+    STRUCTURAL_MATCH_PARAM_MISMATCH = "STRUCTURAL_MATCH_PARAM_MISMATCH"
+    STRUCTURAL_MISMATCH = "STRUCTURAL_MISMATCH"
+    HASH_UNAVAILABLE = "HASH_UNAVAILABLE"
+
+
+@dataclass
+class FormatOptions:
+    """
+    Formatting options for text reports.
+
+    Attributes
+    ----------
+    max_drifts : int
+        Maximum drift metrics to display. Default is 5.
+    max_circuit_changes : int
+        Maximum circuit changes to display. Default is 10.
+    max_param_changes : int
+        Maximum parameter changes to display. Default is 10.
+    max_metric_changes : int
+        Maximum metric changes to display. Default is 10.
+    show_evidence : bool
+        Show detailed evidence in verdicts. Default is True.
+    width : int
+        Line width for text output. Default is 70.
+    """
+
+    max_drifts: int = 5
+    max_circuit_changes: int = 10
+    max_param_changes: int = 10
+    max_metric_changes: int = 10
+    show_evidence: bool = True
+    width: int = 70

--- a/packages/devqubit-engine/src/devqubit_engine/compare/verify.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/verify.py
@@ -6,6 +6,10 @@ Baseline verification for CI/regression testing.
 
 This module provides policy-based verification of a candidate run against
 a baseline run, with bootstrap-calibrated noise thresholds.
+
+Architecture:
+- Core functions (verify_contexts) operate entirely on RunContext/envelope
+- Adapter functions (verify, verify_against_baseline) handle RunRecord/registry IO
 """
 
 from __future__ import annotations
@@ -15,11 +19,12 @@ import time
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
-from devqubit_engine.compare.diff import diff_runs
+from devqubit_engine.compare.diff import RunContext, diff_contexts
 from devqubit_engine.compare.results import ProgramMatchMode, VerifyResult
-from devqubit_engine.compare.verdict import build_verdict
+from devqubit_engine.compare.verdict import build_verdict_contexts
 from devqubit_engine.storage.types import ObjectStoreProtocol
 from devqubit_engine.tracking.record import RunRecord
+from devqubit_engine.uec.api.resolve import resolve_envelope
 
 
 logger = logging.getLogger(__name__)
@@ -134,6 +139,18 @@ class VerifyPolicy:
         If set, fail if tvd > noise_factor * noise_p95.
         Uses bootstrap-calibrated noise_p95 threshold.
         Recommended: 1.0-1.5 for CI gating (since p95 is already conservative).
+    noise_alpha : float
+        Quantile level for noise_p95 threshold. Default is 0.95.
+        Use 0.99 for stricter false positive control in production CI.
+    noise_n_boot : int
+        Number of bootstrap iterations for noise estimation. Default is 1000.
+        Use 1000-3000 for CI gating decisions.
+    noise_seed : int or None
+        Random seed for reproducible noise estimation.
+        Default is 12345 for deterministic results.
+    noise_pvalue_cutoff : float or None
+        If set, only fail when p_value < cutoff in addition to
+        tvd > threshold. This reduces false positives. Default is None.
     allow_missing_baseline : bool
         If True, verification passes when no baseline exists.
         Default is False.
@@ -147,8 +164,8 @@ class VerifyPolicy:
     - noise_factor=1.2: Slightly more lenient (recommended for noisy hardware)
     - noise_factor=1.5: Very lenient (use for exploratory runs)
 
-    For strict production CI, consider using alpha=0.99 in noise computation
-    (via diff_runs kwargs) combined with noise_factor=1.0.
+    For strict production CI, consider using noise_alpha=0.99 combined with
+    noise_factor=1.0 and noise_pvalue_cutoff=0.05.
     """
 
     params_must_match: bool = True
@@ -157,6 +174,10 @@ class VerifyPolicy:
     fingerprint_must_match: bool = False
     tvd_max: float | None = None
     noise_factor: float | None = None
+    noise_alpha: float = 0.95
+    noise_n_boot: int = 1000
+    noise_seed: int | None = 12345
+    noise_pvalue_cutoff: float | None = None
     allow_missing_baseline: bool = False
 
     @classmethod
@@ -205,6 +226,14 @@ class VerifyPolicy:
             fingerprint_must_match=bool(d.get("fingerprint_must_match", False)),
             tvd_max=_opt_float("tvd_max", d.get("tvd_max")),
             noise_factor=_opt_float("noise_factor", d.get("noise_factor")),
+            noise_alpha=float(d.get("noise_alpha", 0.95)),
+            noise_n_boot=int(d.get("noise_n_boot", 1000)),
+            noise_seed=(
+                int(d["noise_seed"]) if d.get("noise_seed") is not None else 12345
+            ),
+            noise_pvalue_cutoff=_opt_float(
+                "noise_pvalue_cutoff", d.get("noise_pvalue_cutoff")
+            ),
             allow_missing_baseline=bool(d.get("allow_missing_baseline", False)),
         )
 
@@ -216,11 +245,17 @@ class VerifyPolicy:
             "program_match_mode": self.program_match_mode.value,
             "fingerprint_must_match": self.fingerprint_must_match,
             "allow_missing_baseline": self.allow_missing_baseline,
+            "noise_alpha": self.noise_alpha,
+            "noise_n_boot": self.noise_n_boot,
         }
         if self.tvd_max is not None:
             d["tvd_max"] = self.tvd_max
         if self.noise_factor is not None:
             d["noise_factor"] = self.noise_factor
+        if self.noise_seed is not None:
+            d["noise_seed"] = self.noise_seed
+        if self.noise_pvalue_cutoff is not None:
+            d["noise_pvalue_cutoff"] = self.noise_pvalue_cutoff
         return d
 
 
@@ -231,6 +266,185 @@ def _normalize_policy(policy: VerifyPolicy | dict[str, Any] | None) -> VerifyPol
     if isinstance(policy, dict):
         return VerifyPolicy.from_dict(policy)
     return policy
+
+
+# =============================================================================
+# Core: Envelope-only verification
+# =============================================================================
+
+
+def verify_contexts(
+    ctx_baseline: RunContext,
+    ctx_candidate: RunContext,
+    policy: VerifyPolicy,
+) -> VerifyResult:
+    """
+    Verify a candidate against baseline using envelope-only comparison.
+
+    This is the core verification function operating entirely on RunContext
+    (envelope + store). All verification logic (thresholds, fingerprint gating,
+    noise logic) is evaluated here without any RunRecord dependencies.
+
+    Parameters
+    ----------
+    ctx_baseline : RunContext
+        Baseline context with resolved envelope.
+    ctx_candidate : RunContext
+        Candidate context with resolved envelope.
+    policy : VerifyPolicy
+        Verification policy defining pass/fail criteria.
+
+    Returns
+    -------
+    VerifyResult
+        Verification result with ok status, failures, comparison, and verdict.
+
+    Notes
+    -----
+    Use the adapter functions (verify, verify_against_baseline) if you have
+    RunRecord or run_id inputs. This function is for direct envelope access.
+    """
+    start = time.perf_counter()
+
+    logger.info(
+        "Verifying %s against baseline %s",
+        ctx_candidate.run_id,
+        ctx_baseline.run_id,
+    )
+
+    # Core comparison via diff_contexts
+    comparison = diff_contexts(
+        ctx_baseline,
+        ctx_candidate,
+        include_circuit_diff=False,
+        include_noise_context=bool(policy.noise_factor),
+        noise_alpha=policy.noise_alpha,
+        noise_n_boot=policy.noise_n_boot,
+        noise_seed=policy.noise_seed if policy.noise_seed is not None else 12345,
+    )
+
+    failures: list[str] = []
+
+    # Check fingerprint match
+    if policy.fingerprint_must_match:
+        if comparison.fingerprint_a and comparison.fingerprint_b:
+            if comparison.fingerprint_a != comparison.fingerprint_b:
+                failures.append(
+                    f"fingerprint mismatch: baseline={comparison.fingerprint_a} "
+                    f"candidate={comparison.fingerprint_b}"
+                )
+        else:
+            failures.append(
+                "fingerprint missing: cannot enforce fingerprint_must_match"
+            )
+
+    # Check params match
+    if policy.params_must_match and not comparison.params.get("match", False):
+        changed = comparison.params.get("changed", {})
+        added = comparison.params.get("added", {})
+        removed = comparison.params.get("removed", {})
+        failures.append(
+            f"params differ: {len(changed)} changed, "
+            f"{len(removed)} only in baseline, {len(added)} only in candidate"
+        )
+
+    # Check program match (using policy's match mode)
+    if policy.program_must_match:
+        program_ok = comparison.program_matches(policy.program_match_mode)
+        if not program_ok:
+            mode_desc = {
+                ProgramMatchMode.EXACT: "exact artifact match required",
+                ProgramMatchMode.STRUCTURAL: "structural match required",
+                ProgramMatchMode.EITHER: "no match (neither exact nor structural)",
+            }
+            failures.append(
+                f"program artifacts differ ({mode_desc[policy.program_match_mode]})"
+            )
+
+    # Check TVD threshold (with bootstrap-calibrated noise option)
+    if comparison.tvd is not None:
+        effective_threshold = policy.tvd_max
+
+        # Apply noise-aware threshold using bootstrap-calibrated p95
+        if policy.noise_factor and comparison.noise_context:
+            noise_threshold = policy.noise_factor * comparison.noise_context.noise_p95
+
+            if effective_threshold is None:
+                effective_threshold = noise_threshold
+            else:
+                effective_threshold = max(effective_threshold, noise_threshold)
+
+        if effective_threshold is not None and comparison.tvd > effective_threshold:
+            # Check p-value cutoff if configured (reduces false positives)
+            should_fail = True
+            if policy.noise_pvalue_cutoff is not None and comparison.noise_context:
+                p_value = comparison.noise_context.p_value
+                if p_value is not None and p_value >= policy.noise_pvalue_cutoff:
+                    should_fail = False
+                    comparison.warnings.append(
+                        f"TVD ({comparison.tvd:.6f}) exceeds threshold "
+                        f"({effective_threshold:.6f}) but p-value ({p_value:.4f}) "
+                        f">= cutoff ({policy.noise_pvalue_cutoff}). Not failing."
+                    )
+
+            if should_fail:
+                if policy.noise_factor and comparison.noise_context:
+                    ctx = comparison.noise_context
+                    p_value_info = ""
+                    if ctx.p_value is not None:
+                        p_value_info = f", p-value={ctx.p_value:.4f}"
+
+                    failures.append(
+                        f"TVD too high: {comparison.tvd:.6f} > "
+                        f"{effective_threshold:.6f} "
+                        f"(noise_factor={policy.noise_factor}x noise_p95 of "
+                        f"{ctx.noise_p95:.6f}{p_value_info})"
+                    )
+                else:
+                    failures.append(
+                        f"TVD too high: {comparison.tvd:.6f} > {effective_threshold:.6f}"
+                    )
+    else:
+        # TVD not available (no counts / analytic mode)
+        if policy.tvd_max is not None or policy.noise_factor is not None:
+            comparison.warnings.append(
+                "TVD check skipped: no measurement counts available "
+                "(analytic mode or missing results artifact)"
+            )
+
+    # Build verdict if failures (circuit diff computed on-demand here)
+    verdict = None
+    if failures:
+        verdict = build_verdict_contexts(
+            result=comparison,
+            ctx_a=ctx_baseline,
+            ctx_b=ctx_candidate,
+        )
+
+    duration_ms = (time.perf_counter() - start) * 1000
+
+    result = VerifyResult(
+        ok=len(failures) == 0,
+        failures=failures,
+        comparison=comparison,
+        baseline_run_id=ctx_baseline.run_id,
+        candidate_run_id=ctx_candidate.run_id,
+        duration_ms=duration_ms,
+        verdict=verdict,
+    )
+
+    logger.info(
+        "Verification %s in %.1fms",
+        "PASSED" if result.ok else f"FAILED ({len(failures)} failures)",
+        duration_ms,
+    )
+
+    return result
+
+
+# =============================================================================
+# Adapters: RunRecord/registry to RunContext conversion
+# =============================================================================
 
 
 def verify(
@@ -244,9 +458,8 @@ def verify(
     """
     Verify a candidate run against a baseline run.
 
-    Performs comparison and applies policy checks to determine
-    pass/fail status. Uses bootstrap-calibrated noise thresholds
-    for robust false positive control.
+    This is an adapter function that converts RunRecord inputs to RunContext
+    and delegates to verify_contexts. Use this when you have RunRecord objects.
 
     Parameters
     ----------
@@ -266,133 +479,26 @@ def verify(
     VerifyResult
         Verification result with ok status, failures, and comparison.
     """
-    start = time.perf_counter()
     pol = _normalize_policy(policy)
 
-    logger.info(
-        "Verifying %s against baseline %s",
-        candidate.run_id,
-        baseline.run_id,
+    # Resolve envelopes
+    envelope_baseline = resolve_envelope(baseline, store_baseline)
+    envelope_candidate = resolve_envelope(candidate, store_candidate)
+
+    # Create contexts
+    ctx_baseline = RunContext(
+        run_id=baseline.run_id,
+        envelope=envelope_baseline,
+        store=store_baseline,
+    )
+    ctx_candidate = RunContext(
+        run_id=candidate.run_id,
+        envelope=envelope_candidate,
+        store=store_candidate,
     )
 
-    # Optimize: only compute noise_context if noise_factor is set
-    # Circuit diff is computed on-demand in build_verdict if needed
-    comparison = diff_runs(
-        baseline,
-        candidate,
-        store_a=store_baseline,
-        store_b=store_candidate,
-        include_circuit_diff=False,
-        include_noise_context=bool(pol.noise_factor),
-    )
-
-    failures: list[str] = []
-
-    # Check fingerprint match
-    if pol.fingerprint_must_match:
-        if comparison.fingerprint_a and comparison.fingerprint_b:
-            if comparison.fingerprint_a != comparison.fingerprint_b:
-                failures.append(
-                    f"fingerprint mismatch: baseline={comparison.fingerprint_a} "
-                    f"candidate={comparison.fingerprint_b}"
-                )
-        else:
-            failures.append(
-                "fingerprint missing: cannot enforce fingerprint_must_match"
-            )
-
-    # Check params match
-    if pol.params_must_match and not comparison.params.get("match", False):
-        changed = comparison.params.get("changed", {})
-        added = comparison.params.get("added", {})
-        removed = comparison.params.get("removed", {})
-        failures.append(
-            f"params differ: {len(changed)} changed, "
-            f"{len(removed)} only in baseline, {len(added)} only in candidate"
-        )
-
-    # Check program match (using policy's match mode)
-    if pol.program_must_match:
-        program_ok = comparison.program_matches(pol.program_match_mode)
-        if not program_ok:
-            mode_desc = {
-                ProgramMatchMode.EXACT: "exact artifact match required",
-                ProgramMatchMode.STRUCTURAL: "structural match required",
-                ProgramMatchMode.EITHER: "no match (neither exact nor structural)",
-            }
-            failures.append(
-                f"program artifacts differ ({mode_desc[pol.program_match_mode]})"
-            )
-
-    # Check TVD threshold (with bootstrap-calibrated noise option)
-    if comparison.tvd is not None:
-        effective_threshold = pol.tvd_max
-
-        # Apply noise-aware threshold using bootstrap-calibrated p95
-        if pol.noise_factor and comparison.noise_context:
-            # Use noise_p95 (bootstrap-calibrated) instead of expected_noise
-            noise_threshold = pol.noise_factor * comparison.noise_context.noise_p95
-
-            if effective_threshold is None:
-                effective_threshold = noise_threshold
-            else:
-                effective_threshold = max(effective_threshold, noise_threshold)
-
-        if effective_threshold is not None and comparison.tvd > effective_threshold:
-            if pol.noise_factor and comparison.noise_context:
-                ctx = comparison.noise_context
-                p_value_info = ""
-                if ctx.p_value is not None:
-                    p_value_info = f", p-value={ctx.p_value:.4f}"
-
-                failures.append(
-                    f"TVD too high: {comparison.tvd:.6f} > "
-                    f"{effective_threshold:.6f} "
-                    f"(noise_factor={pol.noise_factor}x noise_p95 of "
-                    f"{ctx.noise_p95:.6f}{p_value_info})"
-                )
-            else:
-                failures.append(
-                    f"TVD too high: {comparison.tvd:.6f} > {effective_threshold:.6f}"
-                )
-    else:
-        # TVD not available (no counts / analytic mode)
-        if pol.tvd_max is not None or pol.noise_factor is not None:
-            comparison.warnings.append(
-                "TVD check skipped: no measurement counts available "
-                "(analytic mode or missing results artifact)"
-            )
-
-    # Build verdict if failures (circuit diff computed on-demand here)
-    verdict = None
-    if failures:
-        verdict = build_verdict(
-            result=comparison,
-            run_a=baseline,
-            run_b=candidate,
-            store_a=store_baseline,
-            store_b=store_candidate,
-        )
-
-    duration_ms = (time.perf_counter() - start) * 1000
-
-    result = VerifyResult(
-        ok=len(failures) == 0,
-        failures=failures,
-        comparison=comparison,
-        baseline_run_id=baseline.run_id,
-        candidate_run_id=candidate.run_id,
-        duration_ms=duration_ms,
-        verdict=verdict,
-    )
-
-    logger.info(
-        "Verification %s in %.1fms",
-        "PASSED" if result.ok else f"FAILED ({len(failures)} failures)",
-        duration_ms,
-    )
-
-    return result
+    # Delegate to core
+    return verify_contexts(ctx_baseline, ctx_candidate, pol)
 
 
 def verify_against_baseline(


### PR DESCRIPTION
## Summary

compare module is now based fulyl on envelope.

Fixes critical bugs in compare module:
- item_index="all" now keeps counts consistent with worst TVD item
- Threshold semantics: min() not max() (tvd_max is true hard limit)
- noise_pvalue_cutoff now triggers noise context computation
- Empty programs comparison: [] == [] = identical
- TVD uses tolerance (<= 1e-12) instead of exact == 0.0
- Compiler change detection via executed_structural_hash

The compare module was also refactored for better structure and simplification.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Refactor (no user-facing change)
- [ ] Docs only
- [ ] CI/build tooling
- [ ] Breaking change

## Changelog (user-facing only)
- [x] I added a towncrier fragment in `changelog.d/` (skip for internal-only changes)

## Checklist
- [x] I ran lint locally (`uv run pre-commit run --all-files`)
- [x] I ran tests locally (`uv run pytest`)
- [x] I added/updated tests for behavior changes
- [ ] I updated docs/README/examples if needed
- [ ] If I changed dependencies, I updated `uv.lock` (`uv lock`) and committed it
- [x] I considered backward compatibility and security impact
