### PR TITLE
feat: add run name support across public API and improve diff formatting

### DIFF
--- a/changelog.d/34.added.md
+++ b/changelog.d/34.added.md
@@ -1,0 +1,1 @@
+Support referencing runs by name via `--project` flag in CLI and `project` parameter in API functions (`diff`, `pack_run`, `verify_baseline`).

--- a/packages/devqubit-engine/src/devqubit_engine/cli/__init__.py
+++ b/packages/devqubit-engine/src/devqubit_engine/cli/__init__.py
@@ -37,11 +37,17 @@ Examples
     # Compare two runs
     devqubit diff abc123 def456
 
+    # Compare runs by name
+    devqubit diff baseline-v1 experiment-v2 --project bell_state
+
     # Verify against baseline
     devqubit verify abc123 --project myproject
 
     # Pack a run for sharing
     devqubit pack abc123 -o experiment.zip
+
+    # Pack by name
+    devqubit pack my-experiment --project bell_state -o experiment.zip
 
     # Launch web UI
     devqubit ui --port 8080

--- a/packages/devqubit-engine/src/devqubit_engine/cli/_utils.py
+++ b/packages/devqubit-engine/src/devqubit_engine/cli/_utils.py
@@ -203,11 +203,11 @@ def resolve_run(
     except RunNotFoundError:
         if project:
             raise click.ClickException(
-                f"Run not found: '{run_id_or_name}'"
+                f"Run not found: '{run_id_or_name}' "
                 f"(looked up as ID and as name in project '{project}')"
             )
         raise click.ClickException(
-            f"Run not found: '{run_id_or_name}'." f"Use --project to look up by name."
+            f"Run not found: '{run_id_or_name}'. " f"Use --project to look up by name."
         )
 
 

--- a/packages/devqubit-engine/src/devqubit_engine/cli/admin.py
+++ b/packages/devqubit-engine/src/devqubit_engine/cli/admin.py
@@ -282,14 +282,14 @@ def storage_health(ctx: click.Context, fmt: str) -> None:
     """Check storage health and integrity."""
     from devqubit_engine.config import Config
     from devqubit_engine.storage.factory import create_registry, create_store
-    from devqubit_engine.storage.gc import check_health
+    from devqubit_engine.storage.gc import check_workspace_health
 
     root = root_from_ctx(ctx)
     config = Config(root_dir=root)
     registry = create_registry(config=config)
     store = create_store(config=config)
 
-    health = check_health(store, registry)
+    health = check_workspace_health(store, registry)
 
     if fmt == "json":
         print_json(health)

--- a/packages/devqubit-engine/src/devqubit_engine/cli/bundle.py
+++ b/packages/devqubit-engine/src/devqubit_engine/cli/bundle.py
@@ -87,7 +87,7 @@ def pack_cmd(
 
     try:
         result = pack_run(
-            run_id=run_id_or_name,
+            run_id_or_name,
             output_path=output_path,
             store=store,
             registry=registry,

--- a/packages/devqubit-engine/src/devqubit_engine/cli/bundle.py
+++ b/packages/devqubit-engine/src/devqubit_engine/cli/bundle.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import click
-from devqubit_engine.cli._utils import echo, print_json, root_from_ctx
+from devqubit_engine.cli._utils import echo, is_quiet, print_json, root_from_ctx
 
 
 def register(cli: click.Group) -> None:
@@ -32,15 +32,11 @@ def register(cli: click.Group) -> None:
     cli.add_command(info_cmd)
 
 
-def _is_quiet(ctx: click.Context) -> bool:
-    """Check if quiet mode is enabled."""
-    if ctx.obj is None:
-        return False
-    return bool(ctx.obj.get("quiet", False))
-
-
 @click.command("pack")
-@click.argument("run_id")
+@click.argument("run_id_or_name")
+@click.option(
+    "--project", "-p", default=None, help="Project name (required when using run name)."
+)
 @click.option("--out", "-o", type=click.Path(path_type=Path), help="Output file path.")
 @click.option("--force", "-f", is_flag=True, help="Overwrite existing file.")
 @click.option(
@@ -52,7 +48,8 @@ def _is_quiet(ctx: click.Context) -> bool:
 @click.pass_context
 def pack_cmd(
     ctx: click.Context,
-    run_id: str,
+    run_id_or_name: str,
+    project: str | None,
     out: Path | None,
     force: bool,
     fmt: str,
@@ -63,18 +60,21 @@ def pack_cmd(
     Creates a self-contained ZIP archive containing the run record and
     all referenced artifacts, suitable for sharing or archiving.
 
+    RUN_ID_OR_NAME can be a run ID or run name. When using run name,
+    --project is required.
+
     Examples:
         devqubit pack abc123
         devqubit pack abc123 -o experiment.zip
+        devqubit pack my-experiment --project bell_state -o experiment.zip
         devqubit pack abc123 -o experiment.zip --force
     """
     from devqubit_engine.bundle.pack import pack_run
     from devqubit_engine.config import Config
-    from devqubit_engine.storage.errors import RunNotFoundError
     from devqubit_engine.storage.factory import create_registry, create_store
 
     root = root_from_ctx(ctx)
-    output_path = out or Path(f"{run_id}.devqubit.zip")
+    output_path = out or Path(f"{run_id_or_name}.devqubit.zip")
 
     if output_path.exists() and not force:
         raise click.ClickException(
@@ -85,26 +85,30 @@ def pack_cmd(
     store = create_store(config=config)
     registry = create_registry(config=config)
 
-    # Verify run exists before packing
-    try:
-        registry.load(run_id)
-    except RunNotFoundError as e:
-        raise click.ClickException(f"Run not found: {run_id}") from e
-
     try:
         result = pack_run(
-            run_id=run_id,
+            run_id=run_id_or_name,
             output_path=output_path,
             store=store,
             registry=registry,
+            project=project,
         )
     except Exception as e:
+        error_msg = str(e)
+        if "not found" in error_msg.lower():
+            if project:
+                raise click.ClickException(
+                    f"Run not found: '{run_id_or_name}' (looked up as ID and as name in project '{project}')"
+                ) from e
+            raise click.ClickException(
+                f"Run not found: '{run_id_or_name}'. Use --project to look up by name."
+            ) from e
         raise click.ClickException(f"Pack failed: {e}") from e
 
     if fmt == "json":
         print_json(
             {
-                "run_id": run_id,
+                "run_id": result.run_id,
                 "output_path": str(output_path),
                 "artifact_count": result.artifact_count,
                 "object_count": result.object_count,
@@ -116,8 +120,8 @@ def pack_cmd(
         )
         return
 
-    echo(f"Packed run {run_id} to {output_path}")
-    if not _is_quiet(ctx):
+    echo(f"Packed run {result.run_id} to {output_path}")
+    if not is_quiet(ctx):
         echo(f"  Artifacts: {result.artifact_count}")
         echo(f"  Objects:   {result.object_count}")
         if result.missing_objects:
@@ -209,18 +213,24 @@ def unpack_cmd(
         print_json(
             {
                 "run_id": result.run_id,
+                "bundle_path": str(result.bundle_path),
                 "destination": str(dest),
                 "artifact_count": result.artifact_count,
                 "object_count": result.object_count,
+                "skipped_objects": result.skipped_objects,
+                "missing_objects": result.missing_objects,
+                "total_objects": result.total_objects,
             }
         )
         return
 
     echo(f"Unpacked to {dest}")
-    if not _is_quiet(ctx):
+    if not is_quiet(ctx):
         echo(f"  Run ID:    {result.run_id}")
         echo(f"  Artifacts: {result.artifact_count}")
         echo(f"  Objects:   {result.object_count}")
+        if result.skipped_objects:
+            echo(f"  Skipped:   {len(result.skipped_objects)} (already exist)")
 
 
 @click.command("info")

--- a/packages/devqubit-engine/src/devqubit_engine/cli/runs.py
+++ b/packages/devqubit-engine/src/devqubit_engine/cli/runs.py
@@ -32,6 +32,7 @@ from devqubit_engine.cli._utils import (
     echo,
     print_json,
     print_table,
+    resolve_run,
     root_from_ctx,
     safe_get,
     truncate_id,
@@ -64,6 +65,7 @@ def _get_run_tags(run_record: Any) -> dict[str, Any]:
 @click.option("--status", "-s", default=None, help="Filter by status.")
 @click.option("--backend", "-b", default=None, help="Filter by backend name.")
 @click.option("--group", "-g", default=None, help="Filter by group ID.")
+@click.option("--name", default=None, help="Filter by run name (exact match).")
 @click.option(
     "--tag",
     "-t",
@@ -81,6 +83,7 @@ def list_runs(
     status: str | None,
     backend: str | None,
     group: str | None,
+    name: str | None,
     tags: tuple[str, ...],
     fmt: str,
 ) -> None:
@@ -91,6 +94,7 @@ def list_runs(
         devqubit list
         devqubit list --limit 50 --project myproject
         devqubit list --status COMPLETED --backend ibm_brisbane
+        devqubit list --name baseline-v1 --project bell_state
         devqubit list --tag experiment=bell --tag validated
     """
     from devqubit_engine.config import Config
@@ -111,6 +115,8 @@ def list_runs(
         filter_kwargs["backend_name"] = backend
     if group:
         filter_kwargs["group_id"] = group
+    if name:
+        filter_kwargs["run_name"] = name
 
     runs = registry.list_runs(**filter_kwargs)
 
@@ -153,7 +159,7 @@ def list_runs(
         echo("No runs found.")
         return
 
-    headers = ["Run ID", "Project", "Adapter", "Status", "Created"]
+    headers = ["Run ID", "Name", "Project", "Adapter", "Status", "Created"]
     rows = []
     for r in runs:
         proj = r.get("project")
@@ -166,12 +172,14 @@ def list_runs(
         adapter_name = r.get("adapter") or info.get("adapter", "")
         status_val = r.get("status") or info.get("status", "")
         created = str(r.get("created_at", ""))[:19]
+        run_name = r.get("run_name") or info.get("run_name") or ""
 
         rows.append(
             [
                 truncate_id(r.get("run_id", "")),
-                proj_name[:20],
-                str(adapter_name),
+                run_name[:15] if run_name else "-",
+                proj_name[:15],
+                str(adapter_name)[:12],
                 str(status_val),
                 created,
             ]
@@ -246,16 +254,18 @@ def search_runs(
         echo("No matching runs found.")
         return
 
-    headers = ["Run ID", "Project", "Status", "Created"]
+    headers = ["Run ID", "Name", "Project", "Status", "Created"]
     if sort and sort.startswith("metric."):
         metric_name = sort.split(".", 1)[1]
         headers.append(metric_name[:12])
 
     rows = []
     for r in results:
+        run_name = r.run_name or ""
         row = [
             truncate_id(r.run_id),
-            r.project[:20] if r.project else "",
+            run_name[:15] if run_name else "-",
+            r.project[:15] if r.project else "",
             r.status or "",
             r.created_at[:19] if r.created_at else "",
         ]
@@ -273,7 +283,10 @@ def search_runs(
 
 
 @click.command("show")
-@click.argument("run_id")
+@click.argument("run_id_or_name")
+@click.option(
+    "--project", "-p", default=None, help="Project name (required when using run name)."
+)
 @click.option(
     "--format",
     "fmt",
@@ -281,20 +294,31 @@ def search_runs(
     default="pretty",
 )
 @click.pass_context
-def show_run(ctx: click.Context, run_id: str, fmt: str) -> None:
-    """Show detailed run information."""
+def show_run(
+    ctx: click.Context,
+    run_id_or_name: str,
+    project: str | None,
+    fmt: str,
+) -> None:
+    """
+    Show detailed run information.
+
+    RUN_ID_OR_NAME can be a run ID or run name. When using run name,
+    --project is required.
+
+    Examples:
+        devqubit show abc123
+        devqubit show my-experiment --project bell_state
+        devqubit show abc123 --format json
+    """
     from devqubit_engine.config import Config
-    from devqubit_engine.storage.errors import RunNotFoundError
     from devqubit_engine.storage.factory import create_registry
 
     root = root_from_ctx(ctx)
     config = Config(root_dir=root)
     registry = create_registry(config=config)
 
-    try:
-        run_record = registry.load(run_id)
-    except RunNotFoundError as e:
-        raise click.ClickException(f"Run not found: {run_id}") from e
+    run_record = resolve_run(run_id_or_name, registry, project)
 
     if fmt == "json":
         print_json(run_record.to_dict())
@@ -304,6 +328,8 @@ def show_run(ctx: click.Context, run_id: str, fmt: str) -> None:
     info = record.get("info", {}) or {}
 
     echo(f"Run ID:      {run_record.run_id}")
+    if run_record.name:
+        echo(f"Run name:    {run_record.name}")
     echo(f"Project:     {run_record.project or '-'}")
     echo(f"Adapter:     {run_record.adapter or '-'}")
     echo(f"Status:      {run_record.status or '-'}")
@@ -368,11 +394,29 @@ def show_run(ctx: click.Context, run_id: str, fmt: str) -> None:
 
 
 @click.command("delete")
-@click.argument("run_id")
+@click.argument("run_id_or_name")
+@click.option(
+    "--project", "-p", default=None, help="Project name (required when using run name)."
+)
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation.")
 @click.pass_context
-def delete_run(ctx: click.Context, run_id: str, yes: bool) -> None:
-    """Delete a run and its artifacts."""
+def delete_run(
+    ctx: click.Context,
+    run_id_or_name: str,
+    project: str | None,
+    yes: bool,
+) -> None:
+    """
+    Delete a run and its artifacts.
+
+    RUN_ID_OR_NAME can be a run ID or run name. When using run name,
+    --project is required.
+
+    Examples:
+        devqubit delete abc123
+        devqubit delete my-experiment --project bell_state
+        devqubit delete abc123 --yes
+    """
     from devqubit_engine.config import Config
     from devqubit_engine.storage.factory import create_registry
 
@@ -380,11 +424,15 @@ def delete_run(ctx: click.Context, run_id: str, yes: bool) -> None:
     config = Config(root_dir=root)
     registry = create_registry(config=config)
 
-    if not registry.exists(run_id):
-        raise click.ClickException(f"Run not found: {run_id}")
+    # Resolve to get actual run ID
+    run_record = resolve_run(run_id_or_name, registry, project)
+    run_id = run_record.run_id
 
     if not yes:
-        if not click.confirm(f"Delete run {run_id}? This cannot be undone."):
+        display_name = f"{run_id}"
+        if run_record.name:
+            display_name = f"{run_record.name} ({run_id})"
+        if not click.confirm(f"Delete run {display_name}? This cannot be undone."):
             echo("Cancelled.")
             return
 
@@ -526,12 +574,14 @@ def groups_show(
         echo(f"No runs found in group: {group_id}")
         return
 
-    headers = ["Run ID", "Status", "Created"]
+    headers = ["Run ID", "Name", "Status", "Created"]
     rows = []
     for r in runs:
+        run_name = r.get("run_name") or r.get("info", {}).get("run_name") or ""
         rows.append(
             [
                 truncate_id(r.get("run_id", "")),
+                run_name[:15] if run_name else "-",
                 r.get("status", ""),
                 str(r.get("created_at", ""))[:19],
             ]

--- a/packages/devqubit-engine/src/devqubit_engine/cli/runs.py
+++ b/packages/devqubit-engine/src/devqubit_engine/cli/runs.py
@@ -116,7 +116,7 @@ def list_runs(
     if group:
         filter_kwargs["group_id"] = group
     if name:
-        filter_kwargs["run_name"] = name
+        filter_kwargs["name"] = name  # Fixed: was "run_name", should be "name"
 
     runs = registry.list_runs(**filter_kwargs)
 

--- a/packages/devqubit-engine/src/devqubit_engine/compare/_formatting.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/_formatting.py
@@ -179,13 +179,14 @@ def format_comparison_result(
 
     # Program section
     lines.extend(["", "-" * opts.width, "Program", "-" * opts.width])
-    if result.program.exact_match:
-        prog_status = f"{_SYM_OK} Match (exact)"
+    if not result.program.has_programs:
+        lines.append("  N/A (not captured)")
+    elif result.program.exact_match:
+        lines.append(f"  {_SYM_OK} Match (exact)")
     elif result.program.structural_match:
-        prog_status = f"{_SYM_OK} Match (structural)"
+        lines.append(f"  {_SYM_OK} Match (structural)")
     else:
-        prog_status = f"{_SYM_FAIL} Differ"
-    lines.append(f"  {prog_status}")
+        lines.append(f"  {_SYM_FAIL} Differ")
 
     # Parameters section
     if result.params:

--- a/packages/devqubit-engine/src/devqubit_engine/compare/diff.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/diff.py
@@ -164,7 +164,11 @@ def _compare_programs(
         ]
         digests_b = sorted(set(logical_digests_b + physical_digests_b))
 
-    exact_match = digests_a == digests_b
+    # Check if we have any program artifacts to compare
+    has_programs = bool(digests_a) or bool(digests_b)
+
+    # Exact match only meaningful when both have programs
+    exact_match = has_programs and digests_a == digests_b
 
     # Extract hashes from envelope program snapshot
     hash_a: str | None = None
@@ -175,7 +179,7 @@ def _compare_programs(
     exec_struct_hash_b: str | None = None
     exec_param_hash_a: str | None = None
     exec_param_hash_b: str | None = None
-    hash_available = True
+    hash_available = has_programs
 
     if envelope_a.program:
         hash_a = envelope_a.program.structural_hash
@@ -229,6 +233,7 @@ def _compare_programs(
         )
 
     return ProgramComparison(
+        has_programs=has_programs,
         exact_match=exact_match,
         structural_match=structural_match,
         parametric_match=parametric_match,

--- a/packages/devqubit-engine/src/devqubit_engine/compare/diff.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/diff.py
@@ -167,8 +167,8 @@ def _compare_programs(
     # Check if we have any program artifacts to compare
     has_programs = bool(digests_a) or bool(digests_b)
 
-    # Exact match only meaningful when both have programs
-    exact_match = has_programs and digests_a == digests_b
+    # Exact match: digests are the same
+    exact_match = digests_a == digests_b
 
     # Extract hashes from envelope program snapshot
     hash_a: str | None = None

--- a/packages/devqubit-engine/src/devqubit_engine/compare/results.py
+++ b/packages/devqubit-engine/src/devqubit_engine/compare/results.py
@@ -311,10 +311,9 @@ class ProgramComparison:
         -------
         bool
             True if programs match according to the mode.
-            Returns False if no programs are available.
+            When both runs have no programs ([] == []), exact_match is True
+            and this returns True.
         """
-        if not self.has_programs:
-            return False
         if mode == ProgramMatchMode.EXACT:
             return self.exact_match
         elif mode == ProgramMatchMode.STRUCTURAL:

--- a/packages/devqubit-engine/src/devqubit_engine/storage/backends/local.py
+++ b/packages/devqubit-engine/src/devqubit_engine/storage/backends/local.py
@@ -642,6 +642,7 @@ class LocalRegistry:
         limit: int = 100,
         offset: int = 0,
         project: str | None = None,
+        name: str | None = None,
         adapter: str | None = None,
         status: str | None = None,
         backend_name: str | None = None,
@@ -660,6 +661,8 @@ class LocalRegistry:
             Number of results to skip. Default is 0.
         project : str, optional
             Filter by project name.
+        name : str, optional
+            Filter by run name (exact match).
         adapter : str, optional
             Filter by adapter name.
         status : str, optional
@@ -684,6 +687,9 @@ class LocalRegistry:
         if project:
             conditions.append("project = ?")
             params.append(project)
+        if name:
+            conditions.append("name = ?")
+            params.append(name)
         if adapter:
             conditions.append("adapter = ?")
             params.append(adapter)

--- a/packages/devqubit-engine/src/devqubit_engine/storage/backends/remote_gcs.py
+++ b/packages/devqubit-engine/src/devqubit_engine/storage/backends/remote_gcs.py
@@ -543,6 +543,7 @@ class GCSRegistry:
         fingerprint: str | None,
         git_commit: str | None,
         group_id: str | None = None,
+        name: str | None = None,
     ) -> bool:
         """
         Apply filters to a record.
@@ -551,7 +552,7 @@ class GCSRegistry:
         ----------
         record : dict
             Full run record.
-        project, adapter, status, backend_name, fingerprint, git_commit, group_id
+        project, name, adapter, status, backend_name, fingerprint, git_commit, group_id
             Filter fields.
 
         Returns
@@ -562,6 +563,11 @@ class GCSRegistry:
         proj = record.get("project", {})
         proj_name = proj.get("name", "") if isinstance(proj, dict) else str(proj)
         if project and proj_name != project:
+            return False
+
+        # Filter by run name
+        rec_name = record.get("name", "")
+        if name and rec_name != name:
             return False
 
         rec_adapter = record.get("adapter", "")
@@ -615,6 +621,7 @@ class GCSRegistry:
         limit: int = 100,
         offset: int = 0,
         project: str | None = None,
+        name: str | None = None,
         adapter: str | None = None,
         status: str | None = None,
         backend_name: str | None = None,
@@ -633,6 +640,8 @@ class GCSRegistry:
             Number of results to skip.
         project : str, optional
             Filter by project name.
+        name : str, optional
+            Filter by run name (exact match).
         adapter : str, optional
             Filter by adapter name.
         status : str, optional
@@ -662,6 +671,7 @@ class GCSRegistry:
             if not self._record_matches(
                 record,
                 project=project,
+                name=name,
                 adapter=adapter,
                 status=status,
                 backend_name=backend_name,

--- a/packages/devqubit-engine/src/devqubit_engine/storage/backends/remote_s3.py
+++ b/packages/devqubit-engine/src/devqubit_engine/storage/backends/remote_s3.py
@@ -623,6 +623,7 @@ class S3Registry:
         fingerprint: str | None,
         git_commit: str | None,
         group_id: str | None = None,
+        name: str | None = None,
     ) -> bool:
         """
         Apply filters to a record.
@@ -631,7 +632,7 @@ class S3Registry:
         ----------
         record : dict
             Full run record.
-        project, adapter, status, backend_name, fingerprint, git_commit, group_id
+        project, name, adapter, status, backend_name, fingerprint, git_commit, group_id
             Filter fields.
 
         Returns
@@ -642,6 +643,11 @@ class S3Registry:
         proj = record.get("project", {})
         proj_name = proj.get("name", "") if isinstance(proj, dict) else str(proj)
         if project and proj_name != project:
+            return False
+
+        # Filter by run name
+        rec_name = record.get("name", "")
+        if name and rec_name != name:
             return False
 
         rec_adapter = record.get("adapter", "")
@@ -697,6 +703,7 @@ class S3Registry:
         limit: int = 100,
         offset: int = 0,
         project: str | None = None,
+        name: str | None = None,
         adapter: str | None = None,
         status: str | None = None,
         backend_name: str | None = None,
@@ -715,6 +722,8 @@ class S3Registry:
             Number of results to skip.
         project : str, optional
             Filter by project name.
+        name : str, optional
+            Filter by run name (exact match).
         adapter : str, optional
             Filter by adapter name.
         status : str, optional
@@ -745,6 +754,7 @@ class S3Registry:
             if not self._record_matches(
                 record,
                 project=project,
+                name=name,
                 adapter=adapter,
                 status=status,
                 backend_name=backend_name,

--- a/packages/devqubit-engine/src/devqubit_engine/storage/types.py
+++ b/packages/devqubit-engine/src/devqubit_engine/storage/types.py
@@ -161,6 +161,8 @@ class RunSummary(TypedDict, total=False):
     ----------
     run_id : str
         Unique run identifier.
+    run_name : str or None
+        Human-readable run name.
     project : str
         Project name.
     adapter : str
@@ -180,6 +182,7 @@ class RunSummary(TypedDict, total=False):
     """
 
     run_id: str
+    run_name: str | None
     project: str
     adapter: str
     status: str
@@ -441,6 +444,7 @@ class RegistryProtocol(Protocol):
         limit: int = 100,
         offset: int = 0,
         project: str | None = None,
+        name: str | None = None,
         adapter: str | None = None,
         status: str | None = None,
         backend_name: str | None = None,
@@ -459,6 +463,8 @@ class RegistryProtocol(Protocol):
             Number of results to skip. Default is 0.
         project : str, optional
             Filter by project name.
+        name : str, optional
+            Filter by run name (exact match).
         adapter : str, optional
             Filter by adapter name.
         status : str, optional

--- a/packages/devqubit-engine/src/devqubit_engine/tracking/record.py
+++ b/packages/devqubit-engine/src/devqubit_engine/tracking/record.py
@@ -273,6 +273,18 @@ class RunRecord:
             return None
 
     @property
+    def name(self) -> str | None:
+        """
+        Alias for run_name.
+
+        Returns
+        -------
+        str or None
+            Run name, or None if not set.
+        """
+        return self.run_name
+
+    @property
     def ended_at(self) -> str | None:
         """
         Get the run end timestamp.

--- a/packages/devqubit-engine/tests/test_bundle.py
+++ b/packages/devqubit-engine/tests/test_bundle.py
@@ -51,7 +51,7 @@ class TestBundleRoundtrip:
 
         # Pack from workspace A
         pack_result = pack_run(
-            run_id=run_id,
+            run_id,
             output_path=bundle_path,
             store=store_a,
             registry=reg_a,
@@ -95,7 +95,7 @@ class TestPackRun:
             run_id = run.run_id
 
         pack_run(
-            run_id=run_id,
+            run_id,
             output_path=bundle_path,
             store=store,
             registry=registry,
@@ -138,7 +138,7 @@ class TestPackRun:
 
         with pytest.raises(FileNotFoundError, match="Missing"):
             pack_run(
-                run_id=run_id,
+                run_id,
                 output_path=bundle_path,
                 store=store,
                 registry=registry,
@@ -157,7 +157,7 @@ class TestUnpackBundle:
             run_id = run.run_id
 
         pack_run(
-            run_id=run_id,
+            run_id,
             output_path=bundle_path,
             store=store,
             registry=registry,
@@ -179,7 +179,7 @@ class TestUnpackBundle:
             run_id = run.run_id
 
         pack_run(
-            run_id=run_id,
+            run_id,
             output_path=bundle_path,
             store=store,
             registry=registry,
@@ -213,7 +213,7 @@ class TestBundleReader:
             run_id = run.run_id
 
         pack_run(
-            run_id=run_id,
+            run_id,
             output_path=bundle_path,
             store=store,
             registry=registry,

--- a/packages/devqubit-engine/tests/test_diff.py
+++ b/packages/devqubit-engine/tests/test_diff.py
@@ -308,7 +308,11 @@ class TestProgramMatching:
 
     def test_exact_match(self):
         """EXACT mode requires identical artifacts."""
-        comp = ProgramComparison(exact_match=True, structural_match=True)
+        comp = ProgramComparison(
+            exact_match=True,
+            structural_match=True,
+            has_programs=True,
+        )
 
         assert comp.matches(ProgramMatchMode.EXACT)
         assert comp.matches(ProgramMatchMode.STRUCTURAL)
@@ -316,7 +320,11 @@ class TestProgramMatching:
 
     def test_structural_only_match(self):
         """Structural match without exact match (VQE scenario)."""
-        comp = ProgramComparison(exact_match=False, structural_match=True)
+        comp = ProgramComparison(
+            exact_match=False,
+            structural_match=True,
+            has_programs=True,
+        )
 
         assert not comp.matches(ProgramMatchMode.EXACT)
         assert comp.matches(ProgramMatchMode.STRUCTURAL)
@@ -325,7 +333,11 @@ class TestProgramMatching:
 
     def test_no_match(self):
         """No match fails all modes."""
-        comp = ProgramComparison(exact_match=False, structural_match=False)
+        comp = ProgramComparison(
+            exact_match=False,
+            structural_match=False,
+            has_programs=True,
+        )
 
         assert not comp.matches(ProgramMatchMode.EXACT)
         assert not comp.matches(ProgramMatchMode.STRUCTURAL)
@@ -338,6 +350,7 @@ class TestProgramMatching:
             structural_match=True,
             digests_a=[],
             digests_b=[],
+            has_programs=False,
         )
 
         assert comp.matches(ProgramMatchMode.EXACT)

--- a/src/devqubit/bundle.py
+++ b/src/devqubit/bundle.py
@@ -10,12 +10,17 @@ that can be shared, archived, or used for offline verification.
 Packing
 -------
 >>> from devqubit.bundle import pack_run
->>> pack_run("run_id", "experiment.zip")
+>>> result = pack_run("run_id", "experiment.zip")
+>>> print(f"Packed {result.object_count} objects")
+
+>>> # Or by name within a project
+>>> result = pack_run("nightly-v1", "experiment.zip", project="bell_state")
 
 Unpacking
 ---------
 >>> from devqubit.bundle import unpack_bundle
->>> unpack_bundle("experiment.zip")
+>>> result = unpack_bundle("experiment.zip")
+>>> print(f"Restored {result.object_count} new objects")
 
 Reading Bundles
 ---------------
@@ -48,11 +53,15 @@ __all__ = [
     "Bundle",
     "list_bundle_contents",
     "replay",
+    "PackResult",
+    "UnpackResult",
 ]
 
 
 if TYPE_CHECKING:
     from devqubit_engine.bundle.pack import (
+        PackResult,
+        UnpackResult,
         list_bundle_contents,
         pack_run,
         unpack_bundle,
@@ -67,6 +76,8 @@ _LAZY_IMPORTS = {
     "list_bundle_contents": ("devqubit_engine.bundle.pack", "list_bundle_contents"),
     "Bundle": ("devqubit_engine.bundle.reader", "Bundle"),
     "replay": ("devqubit_engine.bundle.replay", "replay"),
+    "PackResult": ("devqubit_engine.bundle.pack", "PackResult"),
+    "UnpackResult": ("devqubit_engine.bundle.pack", "UnpackResult"),
 }
 
 

--- a/src/devqubit/compare.py
+++ b/src/devqubit/compare.py
@@ -13,6 +13,9 @@ Diff
 >>> result = diff("run_a", "run_b")
 >>> print(result.identical)
 
+>>> # By run name (requires project)
+>>> result = diff("baseline-v1", "experiment-v2", project="bell_state")
+
 Verification
 ------------
 >>> from devqubit.compare import verify_baseline
@@ -108,7 +111,7 @@ if TYPE_CHECKING:
 
 
 _LAZY_IMPORTS = {
-    # Core comparision function
+    # Core comparison function
     "diff": ("devqubit_engine.compare.diff", "diff"),
     # Result types
     "ComparisonResult": ("devqubit_engine.compare.results", "ComparisonResult"),
@@ -150,8 +153,8 @@ def verify_baseline(
     ----------
     candidate : str, Path, or RunRecord
         Candidate to verify. Can be:
-
         - A run ID (str)
+        - A run name within the project (str)
         - A path to a bundle file (Path or str ending in .zip)
         - A RunRecord instance (already loaded)
     project : str
@@ -227,7 +230,7 @@ def verify_baseline(
     from devqubit_engine.config import get_config
     from devqubit_engine.storage.factory import create_registry, create_store
     from devqubit_engine.storage.types import ArtifactRef
-    from devqubit_engine.tracking.record import RunRecord
+    from devqubit_engine.tracking.record import RunRecord, resolve_run_id
 
     if store is None or registry is None:
         cfg = get_config()
@@ -266,7 +269,9 @@ def verify_baseline(
             )
 
     else:
-        candidate_record = registry.load(str(candidate))
+        # Resolve name to ID if needed
+        run_id = resolve_run_id(str(candidate), project, registry)
+        candidate_record = registry.load(run_id)
 
     return _verify_against_baseline(
         candidate_record,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -43,7 +43,7 @@ class TestFullWorkflow:
         # Pack
         bundle_path = tmp_path / "run.zip"
         pack_run(
-            run_id=run_id,
+            run_id,
             output_path=bundle_path,
             store=store,
             registry=registry,
@@ -191,7 +191,7 @@ class TestDiffWorkflows:
             run_id = run.run_id
 
         pack_run(
-            run_id=run_id,
+            run_id,
             output_path=bundle_path,
             store=store,
             registry=registry,
@@ -225,7 +225,7 @@ class TestDiffWorkflows:
             run_id_a = run_a.run_id
 
         pack_run(
-            run_id=run_id_a,
+            run_id_a,
             output_path=bundle_a,
             store=store,
             registry=registry,
@@ -240,7 +240,7 @@ class TestDiffWorkflows:
             run_id_b = run_b.run_id
 
         pack_run(
-            run_id=run_id_b,
+            run_id_b,
             output_path=bundle_b,
             store=store,
             registry=registry,
@@ -288,7 +288,7 @@ class TestArtifactRoundtrip:
             digest = ref.digest
 
         pack_run(
-            run_id=run_id,
+            run_id,
             output_path=bundle_path,
             store=store_src,
             registry=reg_src,

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -140,7 +140,7 @@ class TestBundle:
         bundle_path = tmp_path / "test.zip"
 
         result = pack_run(
-            run_id=run.run_id,
+            run.run_id,
             output_path=bundle_path,
             store=create_store(config=config),
             registry=create_registry(config=config),
@@ -163,7 +163,7 @@ class TestBundle:
         bundle_path = tmp_path / "reader.zip"
 
         pack_run(
-            run_id=run.run_id,
+            run.run_id,
             output_path=bundle_path,
             store=create_store(config=config),
             registry=create_registry(config=config),


### PR DESCRIPTION
## Summary
Adds ability to reference runs by name (not just ID) across public API and CLI. Also improves comparison output formatting for clarity.

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Refactor (no user-facing change)
- [ ] Docs only
- [ ] CI/build tooling
- [ ] Breaking change

## Changelog (user-facing only)
- [x] I added a towncrier fragment in `changelog.d/` (skip for internal-only changes)

## Checklist
- [x] I ran lint locally (`uv run pre-commit run --all-files`)
- [x] I ran tests locally (`uv run pytest`)
- [x] I added/updated tests for behavior changes
- [ ] I updated docs/README/examples if needed
- [ ] If I changed dependencies, I updated `uv.lock` (`uv lock`) and committed it
- [x] I considered backward compatibility and security impact

## Notes
- Backward compatible: existing run_id calls work unchanged
- Name resolution requires project to prevent ambiguity across projects
- Resolution order: try as ID first (fast path), then name lookup