### PR TITLE
fix(storage): use correct run_name column in list_runs queries

### DIFF
--- a/changelog.d/+list_runs.fixed.md
+++ b/changelog.d/+list_runs.fixed.md
@@ -1,0 +1,1 @@
+Fix `list_runs` failing with "no such column: name" when filtering by run name due to missing `run_name` column in queries.

--- a/packages/devqubit-engine/src/devqubit_engine/storage/backends/local.py
+++ b/packages/devqubit-engine/src/devqubit_engine/storage/backends/local.py
@@ -688,7 +688,7 @@ class LocalRegistry:
             conditions.append("project = ?")
             params.append(project)
         if name:
-            conditions.append("name = ?")
+            conditions.append("run_name = ?")
             params.append(name)
         if adapter:
             conditions.append("adapter = ?")
@@ -715,7 +715,7 @@ class LocalRegistry:
         with self._get_connection() as conn:
             rows = conn.execute(
                 f"""
-                SELECT run_id, project, adapter, status, created_at, ended_at,
+                SELECT run_id, run_name, project, adapter, status, created_at, ended_at,
                        group_id, group_name, parent_run_id
                 FROM runs {where_clause}
                 ORDER BY created_at DESC
@@ -727,6 +727,7 @@ class LocalRegistry:
         return [
             RunSummary(
                 run_id=row["run_id"],
+                run_name=row["run_name"],
                 project=row["project"],
                 adapter=row["adapter"],
                 status=row["status"],
@@ -988,7 +989,7 @@ class LocalRegistry:
         with self._get_connection() as conn:
             rows = conn.execute(
                 """
-                SELECT run_id, project, adapter, status, created_at, ended_at,
+                SELECT run_id, run_name, project, adapter, status, created_at, ended_at,
                        group_id, group_name, parent_run_id
                 FROM runs
                 WHERE group_id = ?
@@ -1001,6 +1002,7 @@ class LocalRegistry:
         return [
             RunSummary(
                 run_id=row["run_id"],
+                run_name=row["run_name"],
                 project=row["project"],
                 adapter=row["adapter"],
                 status=row["status"],

--- a/packages/devqubit-engine/src/devqubit_engine/storage/backends/remote_gcs.py
+++ b/packages/devqubit-engine/src/devqubit_engine/storage/backends/remote_gcs.py
@@ -514,6 +514,7 @@ class GCSRegistry:
         info = record.get("info", {})
         rec_status = info.get("status", "") if isinstance(info, dict) else ""
         ended_at = info.get("ended_at") if isinstance(info, dict) else None
+        run_name = info.get("run_name") if isinstance(info, dict) else None
 
         # Extract group info
         group_id = record.get("group_id")
@@ -522,6 +523,7 @@ class GCSRegistry:
 
         return RunSummary(
             run_id=run_id,
+            run_name=run_name,
             project=proj_name,
             adapter=rec_adapter,
             status=rec_status,
@@ -565,8 +567,8 @@ class GCSRegistry:
         if project and proj_name != project:
             return False
 
-        # Filter by run name
-        rec_name = record.get("name", "")
+        info = record.get("info", {})
+        rec_name = info.get("run_name", "") if isinstance(info, dict) else ""
         if name and rec_name != name:
             return False
 
@@ -574,7 +576,6 @@ class GCSRegistry:
         if adapter and rec_adapter != adapter:
             return False
 
-        info = record.get("info", {})
         rec_status = info.get("status", "") if isinstance(info, dict) else ""
         if status and rec_status != status:
             return False

--- a/packages/devqubit-engine/src/devqubit_engine/storage/backends/remote_s3.py
+++ b/packages/devqubit-engine/src/devqubit_engine/storage/backends/remote_s3.py
@@ -594,6 +594,7 @@ class S3Registry:
         info = record.get("info", {})
         rec_status = info.get("status", "") if isinstance(info, dict) else ""
         ended_at = info.get("ended_at") if isinstance(info, dict) else None
+        run_name = info.get("run_name") if isinstance(info, dict) else None
 
         # Extract group info
         group_id = record.get("group_id")
@@ -602,6 +603,7 @@ class S3Registry:
 
         return RunSummary(
             run_id=run_id,
+            run_name=run_name,
             project=proj_name,
             adapter=rec_adapter,
             status=rec_status,
@@ -645,8 +647,8 @@ class S3Registry:
         if project and proj_name != project:
             return False
 
-        # Filter by run name
-        rec_name = record.get("name", "")
+        info = record.get("info", {})
+        rec_name = info.get("run_name", "") if isinstance(info, dict) else ""
         if name and rec_name != name:
             return False
 
@@ -654,7 +656,6 @@ class S3Registry:
         if adapter and rec_adapter != adapter:
             return False
 
-        info = record.get("info", {})
         rec_status = info.get("status", "") if isinstance(info, dict) else ""
         if status and rec_status != status:
             return False

--- a/packages/devqubit-engine/tests/conftest.py
+++ b/packages/devqubit-engine/tests/conftest.py
@@ -102,6 +102,7 @@ def run_factory() -> Callable[..., RunRecord]:
         backend_type: str = "simulator",
         provider: str = "test_provider",
         status: str = "FINISHED",
+        run_name: str | None = None,
         params: dict[str, Any] | None = None,
         metrics: dict[str, Any] | None = None,
         tags: dict[str, Any] | None = None,
@@ -133,6 +134,8 @@ def run_factory() -> Callable[..., RunRecord]:
             },
         }
 
+        if run_name:
+            record["info"]["run_name"] = run_name
         if group_id:
             record["group_id"] = group_id
         if group_name:

--- a/packages/devqubit-engine/tests/test_storage.py
+++ b/packages/devqubit-engine/tests/test_storage.py
@@ -101,6 +101,64 @@ class TestRegistry:
         assert len(runs) == 2
         assert all(r["project"] == "project_a" for r in runs)
 
+    def test_list_runs_by_name(self, registry, run_factory):
+        """list_runs filters by run name."""
+        registry.save(
+            run_factory(
+                run_id="NAME_A_1",
+                project="proj",
+                run_name="baseline-v1",
+            ).to_dict()
+        )
+        registry.save(
+            run_factory(
+                run_id="NAME_A_2",
+                project="proj",
+                run_name="baseline-v2",
+            ).to_dict()
+        )
+        registry.save(
+            run_factory(
+                run_id="NAME_A_3",
+                project="proj",
+                run_name="experiment-1",
+            ).to_dict()
+        )
+
+        runs = registry.list_runs(project="proj", name="baseline-v1")
+
+        assert len(runs) == 1
+        assert runs[0]["run_id"] == "NAME_A_1"
+
+    def test_list_runs_returns_run_name(self, registry, run_factory):
+        """list_runs includes run_name in results."""
+        registry.save(
+            run_factory(
+                run_id="RNAME001",
+                run_name="my-experiment",
+            ).to_dict()
+        )
+
+        runs = registry.list_runs()
+        run = next(r for r in runs if r["run_id"] == "RNAME001")
+
+        assert run.get("run_name") == "my-experiment"
+
+    def test_list_runs_in_group_returns_run_name(self, registry, run_factory):
+        """list_runs_in_group includes run_name in results."""
+        registry.save(
+            run_factory(
+                run_id="GRPNAME1",
+                run_name="grouped-run",
+                group_id="test_group",
+            ).to_dict()
+        )
+
+        runs = registry.list_runs_in_group("test_group")
+
+        assert len(runs) == 1
+        assert runs[0].get("run_name") == "grouped-run"
+
 
 class TestRegistrySearch:
     """Tests for search_runs query functionality."""


### PR DESCRIPTION
## Summary
Fix `list_runs` failing with `sqlite3.OperationalError: no such column: name` when filtering by run name.

The `list_runs` method was referencing a non-existent `name` column instead of the actual `run_name` column in the database schema. Additionally, `run_name` was missing from SELECT queries and `RunSummary` results.

**Changes:**
- `local.py`: Fix SQL to use `run_name` column, add to SELECT and RunSummary
- `remote_gcs.py` / `remote_s3.py`: Fix `_record_matches` to read `info.run_name` instead of top-level `name`; add `run_name` to `_summarize_record`
- `conftest.py`: Add `run_name` parameter to `run_factory` fixture
- `test_storage.py`: Add tests for name filtering and regression tests

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no user-facing change)
- [ ] Docs only
- [ ] CI/build tooling
- [ ] Breaking change

## Related issues / context
Reproducer:
```bash
devqubit artifacts list baseline-v1 --project bell-state
# Error: no such column: name
```

## Changelog (user-facing only)
- [x] I added a towncrier fragment in `changelog.d/`

## Checklist
- [x] I ran lint locally (`uv run pre-commit run --all-files`)
- [x] I ran tests locally (`uv run pytest`)
- [x] I added/updated tests for behavior changes
- [ ] I updated docs/README/examples if needed
- [ ] If I changed dependencies, I updated `uv.lock` (`uv lock`) and committed it
- [x] I considered backward compatibility and security impact

## Notes for reviewers
The fix is straightforward - the schema defines `run_name` (line 314 in local.py), but the code was looking for `name`. 