### PR TITLE
feature(ui): run deletion UI

### DIFF
--- a/changelog.d/37.added.md
+++ b/changelog.d/37.added.md
@@ -1,0 +1,1 @@
+Add run deletion from UI via detail page modal or inline table buttons.

--- a/packages/devqubit-ui/src/devqubit_ui/services.py
+++ b/packages/devqubit-ui/src/devqubit_ui/services.py
@@ -72,7 +72,7 @@ class RunService:
     """
     Service for run-related operations.
 
-    Encapsulates run listing, filtering, and retrieval logic.
+    Encapsulates run listing, filtering, retrieval, and deletion logic.
 
     Parameters
     ----------
@@ -86,6 +86,7 @@ class RunService:
     >>> service = RunService(registry, store)
     >>> runs = service.list_runs(project="vqe", limit=50)
     >>> run = service.get_run("abc123")
+    >>> service.delete_run("abc123")
     """
 
     def __init__(
@@ -172,6 +173,23 @@ class RunService:
         except Exception as e:
             logger.warning("Run not found: %s", run_id)
             raise KeyError(f"Run not found: {run_id}") from e
+
+    def delete_run(self, run_id: str) -> bool:
+        """
+        Delete a run by ID.
+
+        Parameters
+        ----------
+        run_id : str
+            The run identifier.
+
+        Returns
+        -------
+        bool
+            True if run was deleted, False if it didn't exist.
+        """
+        logger.info("Deleting run: %s", run_id)
+        return self._registry.delete(run_id)
 
     def get_baseline(self, project: str) -> dict[str, Any] | None:
         """

--- a/packages/devqubit-ui/src/devqubit_ui/templates/_groups_table.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/_groups_table.html
@@ -1,4 +1,12 @@
-{# Groups table fragment - can be loaded independently via HTMX #}
+{#
+Groups Table Fragment
+=====================
+Partial template for displaying a table of run groups. Can be loaded
+independently via HTMX for dynamic filtering.
+
+Context variables:
+- groups: List of group dictionaries with group_id, group_name, project, run_count
+#}
 {% if groups %}
 <table>
     <thead>
@@ -16,7 +24,7 @@
             <td class="font-mono">{{ group.group_id | short_id }}</td>
             <td>{{ group.group_name or '—' }}</td>
             <td>{{ group.project }}</td>
-            <td>{{ group.run_count }}</td>
+            <td><span class="badge badge-gray">{{ group.run_count }}</span></td>
             <td>
                 <a href="/groups/{{ group.group_id }}" class="btn btn-sm btn-secondary">View Runs</a>
             </td>
@@ -27,6 +35,6 @@
 {% else %}
 <div class="empty-state">
     <p>No groups found</p>
-    <p class="text-sm mt-2">Groups are created when runs have a group_id set</p>
+    <p class="text-sm text-muted mt-1">Groups are created when runs have a group_id set</p>
 </div>
 {% endif %}

--- a/packages/devqubit-ui/src/devqubit_ui/templates/_projects_table.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/_projects_table.html
@@ -1,3 +1,14 @@
+{#
+Projects Table Fragment
+=======================
+Partial template for displaying a table of projects with their run counts
+and baseline information.
+
+Context variables:
+- projects: List of project dictionaries with name, run_count, baseline
+- current_workspace: Optional workspace context
+#}
+{% if projects %}
 <table>
     <thead>
         <tr>
@@ -37,13 +48,12 @@
                 {% endif %}
             </td>
         </tr>
-        {% else %}
-        <tr>
-            <td colspan="4" class="empty-state">
-                <p>No projects yet</p>
-                <p class="text-sm text-muted mt-1">Projects are created automatically when you log runs</p>
-            </td>
-        </tr>
         {% endfor %}
     </tbody>
 </table>
+{% else %}
+<div class="empty-state">
+    <p>No projects yet</p>
+    <p class="text-sm text-muted mt-1">Projects are created automatically when you log runs</p>
+</div>
+{% endif %}

--- a/packages/devqubit-ui/src/devqubit_ui/templates/_runs_table.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/_runs_table.html
@@ -1,10 +1,19 @@
-{# Runs table fragment - can be loaded independently via HTMX #}
+{#
+Runs Table Fragment
+===================
+Partial template for displaying a table of runs. Can be loaded independently
+via HTMX for dynamic filtering without full page reload.
+
+Context variables:
+- runs: List of run dictionaries
+- filters: Optional filter state for empty state messaging
+#}
 {% if runs %}
 <table>
     <thead>
         <tr>
             <th>Run ID</th>
-            <th>Run Name</th>
+            <th>Name</th>
             <th>Project</th>
             <th>Status</th>
             <th>Created</th>
@@ -13,7 +22,7 @@
     </thead>
     <tbody>
         {% for run in runs %}
-        <tr>
+        <tr id="run-row-{{ run.run_id }}">
             <td>
                 <a href="/runs/{{ run.run_id }}" class="font-mono">
                     {{ run.run_id | short_id }}
@@ -34,7 +43,17 @@
             </td>
             <td class="text-muted">{{ run.created_at | ago }}</td>
             <td>
-                <a href="/runs/{{ run.run_id }}" class="btn btn-sm btn-secondary">View</a>
+                <div class="flex gap-1">
+                    <a href="/runs/{{ run.run_id }}" class="btn btn-sm btn-secondary">View</a>
+                    <button hx-delete="/api/runs/{{ run.run_id }}"
+                            hx-confirm="Delete run {{ run.run_id | short_id }}? This cannot be undone."
+                            hx-target="#run-row-{{ run.run_id }}"
+                            hx-swap="delete"
+                            class="btn btn-sm btn-ghost-danger"
+                            title="Delete run">
+                        Delete
+                    </button>
+                </div>
             </td>
         </tr>
         {% endfor %}
@@ -44,7 +63,7 @@
 <div class="empty-state">
     <p>No runs found</p>
     {% if filters and (filters.q or filters.project or filters.status) %}
-    <p class="text-sm mt-2">Try adjusting your filters</p>
+    <p class="text-sm mt-1">Try adjusting your filters</p>
     {% endif %}
 </div>
 {% endif %}

--- a/packages/devqubit-ui/src/devqubit_ui/templates/artifact.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/artifact.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Artifact - {{ artifact.kind }} - devqubit{% endblock %}
+{% block title %}Artifact · {{ artifact.kind }} · devqubit{% endblock %}
 
 {% block content %}
 <div class="page-header">
@@ -34,7 +34,7 @@
     </div>
 
     {% if error %}
-    <p class="text-sm" style="color: var(--danger);">
+    <p class="text-sm text-danger">
         ⚠ Error loading artifact: {{ error }}
     </p>
     <p class="text-muted mt-2">
@@ -55,7 +55,7 @@
     {% elif content %}
     <pre>{{ content }}</pre>
     {% else %}
-    <p class="text-muted">Binary content ({{ size }} bytes) - download to view</p>
+    <p class="text-muted">Binary content ({{ size }} bytes) — download to view</p>
     {% endif %}
 </div>
 {% endblock %}

--- a/packages/devqubit-ui/src/devqubit_ui/templates/base.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/base.html
@@ -15,6 +15,7 @@
             --primary-light: #4FD194;
             --primary-bg: #EDFAF3;
             --danger: #ef4444;
+            --danger-dark: #dc2626;
             --danger-bg: #fee2e2;
             --warning: #f59e0b;
             --warning-bg: #fef3c7;
@@ -274,8 +275,30 @@
             border-color: var(--danger);
         }
         .btn-danger:hover {
-            background: #dc2626;
-            border-color: #dc2626;
+            background: var(--danger-dark);
+            border-color: var(--danger-dark);
+            color: white;
+            text-decoration: none;
+        }
+
+        .btn-ghost {
+            background: transparent;
+            color: var(--gray-600);
+            border-color: transparent;
+        }
+        .btn-ghost:hover {
+            background: var(--gray-100);
+            color: var(--gray-900);
+        }
+
+        .btn-ghost-danger {
+            background: transparent;
+            color: var(--gray-500);
+            border-color: transparent;
+        }
+        .btn-ghost-danger:hover {
+            background: var(--danger-bg);
+            color: var(--danger);
         }
 
         .btn-sm { padding: 0.375rem 0.75rem; font-size: 0.8125rem; }
@@ -387,6 +410,7 @@
            Utilities
            ================================================================= */
         .text-muted { color: var(--gray-500); }
+        .text-danger { color: var(--danger); }
         .text-sm { font-size: 0.875rem; }
         .text-xs { font-size: 0.75rem; }
         .font-mono { font-family: 'SF Mono', Monaco, 'Courier New', monospace; }
@@ -466,6 +490,59 @@
             animation: spin 0.8s linear infinite;
         }
         @keyframes spin { to { transform: rotate(360deg); } }
+
+        /* =================================================================
+           Modal / Dialog
+           ================================================================= */
+        .modal-backdrop {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.5);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.15s, visibility 0.15s;
+        }
+
+        .modal-backdrop.active {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .modal {
+            background: white;
+            border-radius: 8px;
+            padding: 1.5rem;
+            max-width: 400px;
+            width: 90%;
+            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+            transform: scale(0.95);
+            transition: transform 0.15s;
+        }
+
+        .modal-backdrop.active .modal {
+            transform: scale(1);
+        }
+
+        .modal-title {
+            font-size: 1.125rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+
+        .modal-body {
+            color: var(--gray-600);
+            margin-bottom: 1.5rem;
+        }
+
+        .modal-actions {
+            display: flex;
+            gap: 0.5rem;
+            justify-content: flex-end;
+        }
 
         /* =================================================================
            Scrollbar

--- a/packages/devqubit-ui/src/devqubit_ui/templates/diff.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/diff.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Diff - devqubit{% endblock %}
+{% block title %}Diff · devqubit{% endblock %}
 
 {% block content %}
 <div class="page-header">
@@ -19,23 +19,25 @@
     </div>
 </div>
 
+<!-- Run Headers -->
 <div class="card mb-2">
     <div class="grid grid-2">
         <div>
             <h3 class="text-sm text-muted" style="text-transform: uppercase; letter-spacing: 0.05em;">Run A (Baseline)</h3>
-            <p><a href="/runs/{{ run_a.run_id }}">{{ run_a.run_name or 'Unnamed run' }}</a></p>
+            <p><a href="/runs/{{ run_a.run_id }}">{{ run_a.run_name or 'Unnamed Run' }}</a></p>
             <p class="font-mono text-sm text-muted">{{ run_a.run_id | short_id }}</p>
-            <p class="text-muted text-sm">{{ run_a.project }} / {{ run_a.created_at | ago }}</p>
+            <p class="text-muted text-sm">{{ run_a.project }} · {{ run_a.created_at | ago }}</p>
         </div>
         <div>
             <h3 class="text-sm text-muted" style="text-transform: uppercase; letter-spacing: 0.05em;">Run B (Candidate)</h3>
-            <p><a href="/runs/{{ run_b.run_id }}">{{ run_b.run_name or 'Unnamed run' }}</a></p>
+            <p><a href="/runs/{{ run_b.run_id }}">{{ run_b.run_name or 'Unnamed Run' }}</a></p>
             <p class="font-mono text-sm text-muted">{{ run_b.run_id | short_id }}</p>
-            <p class="text-muted text-sm">{{ run_b.project }} / {{ run_b.created_at | ago }}</p>
+            <p class="text-muted text-sm">{{ run_b.project }} · {{ run_b.created_at | ago }}</p>
         </div>
     </div>
 </div>
 
+<!-- Metadata & Fingerprints -->
 <div class="grid grid-2 mb-2">
     <div class="card">
         <div class="card-header">
@@ -104,6 +106,7 @@
     </div>
 </div>
 
+<!-- Program & Device Calibration -->
 <div class="grid grid-2 mb-2">
     <div class="card">
         <div class="card-header">
@@ -179,7 +182,7 @@
         {% endif %}
 
         {% if report.device_drift and report.device_drift.top_drifts %}
-        <h4 class="text-sm text-muted mb-1" style="margin-top: 1rem;">Top Drifting Metrics</h4>
+        <h4 class="text-sm text-muted mb-1 mt-2">Top Drifting Metrics</h4>
         <table>
             <thead>
                 <tr>
@@ -200,6 +203,7 @@
     </div>
 </div>
 
+<!-- Parameters -->
 <div class="card mb-2">
     <div class="card-header">
         <h3 class="card-title">
@@ -235,7 +239,7 @@
     {% endif %}
 
     {% if report.params.removed %}
-    <h4 class="text-sm text-muted mb-1" style="margin-top: 1rem;">Only in Run A (removed)</h4>
+    <h4 class="text-sm text-muted mb-1 mt-2">Only in Run A</h4>
     <table>
         <thead>
             <tr>
@@ -255,7 +259,7 @@
     {% endif %}
 
     {% if report.params.added %}
-    <h4 class="text-sm text-muted mb-1" style="margin-top: 1rem;">Only in Run B (added)</h4>
+    <h4 class="text-sm text-muted mb-1 mt-2">Only in Run B</h4>
     <table>
         <thead>
             <tr>
@@ -279,6 +283,7 @@
     {% endif %}
 </div>
 
+<!-- Metrics -->
 <div class="card mb-2">
     <div class="card-header">
         <h3 class="card-title">
@@ -314,7 +319,7 @@
     {% endif %}
 
     {% if report.metrics.removed %}
-    <h4 class="text-sm text-muted mb-1" style="margin-top: 1rem;">Only in Run A</h4>
+    <h4 class="text-sm text-muted mb-1 mt-2">Only in Run A</h4>
     <table>
         <thead>
             <tr>
@@ -334,7 +339,7 @@
     {% endif %}
 
     {% if report.metrics.added %}
-    <h4 class="text-sm text-muted mb-1" style="margin-top: 1rem;">Only in Run B</h4>
+    <h4 class="text-sm text-muted mb-1 mt-2">Only in Run B</h4>
     <table>
         <thead>
             <tr>
@@ -358,6 +363,7 @@
     {% endif %}
 </div>
 
+<!-- Circuit Diff -->
 {% if report.circuit_diff %}
 <div class="card mb-2">
     <div class="card-header">
@@ -389,6 +395,7 @@
 </div>
 {% endif %}
 
+<!-- Results / TVD -->
 {% if report.tvd is defined and report.tvd is not none %}
 <div class="card mb-2">
     <div class="card-header">
@@ -425,7 +432,6 @@
 
     {% if report.tvd > 0 and report.noise_context %}
     <p class="text-sm mt-2">
-        {# Bootstrap path: use p_value #}
         {% if report.noise_context.p_value is defined and report.noise_context.p_value is not none %}
             {% if report.noise_context.p_value >= 0.10 %}
             <span style="color: var(--success);">✓</span> Consistent with sampling noise — difference is not statistically significant.
@@ -434,7 +440,6 @@
             {% else %}
             <span style="color: var(--danger);">✗</span> Statistically significant difference (p={{ "%.2f" | format(report.noise_context.p_value) }}) — results show meaningful divergence.
             {% endif %}
-        {# Fallback: use noise_ratio heuristic #}
         {% else %}
             {% if report.noise_context.noise_ratio < 1.5 %}
             <span style="color: var(--success);">✓</span> TVD is within expected shot noise range.
@@ -449,6 +454,7 @@
 </div>
 {% endif %}
 
+<!-- Warnings -->
 {% if report.warnings %}
 <div class="card">
     <div class="card-header">

--- a/packages/devqubit-ui/src/devqubit_ui/templates/diff_select.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/diff_select.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Compare Runs - devqubit{% endblock %}
+{% block title %}Compare Runs · devqubit{% endblock %}
 
 {% block content %}
 <div class="page-header">
@@ -9,7 +9,6 @@
 
 <div class="card">
     <form method="get" action="/diff">
-        <!-- Preserve workspace on compare -->
         {% if current_workspace %}
         <input type="hidden" name="workspace" value="{{ current_workspace.id }}">
         {% endif %}
@@ -19,7 +18,7 @@
                 <select name="a" id="a" required>
                     <option value="">Select run...</option>
                     {% for run in runs %}
-                    <option value="{{ run.run_id }}">{{ run.run_name or 'Unnamed run' }} ({{ run.run_id | short_id }}) - {{ run.project }}</option>
+                    <option value="{{ run.run_id }}">{{ run.run_name or 'Unnamed run' }} ({{ run.run_id | short_id }}) — {{ run.project }}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -28,7 +27,7 @@
                 <select name="b" id="b" required>
                     <option value="">Select run...</option>
                     {% for run in runs %}
-                    <option value="{{ run.run_id }}">{{ run.run_name or 'Unnamed run' }} ({{ run.run_id | short_id }}) - {{ run.project }}</option>
+                    <option value="{{ run.run_id }}">{{ run.run_name or 'Unnamed run' }} ({{ run.run_id | short_id }}) — {{ run.project }}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -38,10 +37,12 @@
 </div>
 
 <div class="card mt-2">
-    <h3 class="card-title mb-1">Tips</h3>
-    <ul class="text-muted text-sm" style="padding-left: 1.5rem;">
-        <li>Select two runs to compare their parameters, metrics, and artifacts</li>
-        <li>The diff will show which parameters changed and compute TVD for result distributions</li>
+    <div class="card-header">
+        <h3 class="card-title">Tips</h3>
+    </div>
+    <ul class="text-muted text-sm" style="padding-left: 1.5rem; margin: 0;">
+        <li style="margin-bottom: 0.25rem;">Select two runs to compare their parameters, metrics, and artifacts</li>
+        <li style="margin-bottom: 0.25rem;">The diff will show which parameters changed and compute TVD for result distributions</li>
         <li>You can also compare from the run detail page against the project baseline</li>
     </ul>
 </div>

--- a/packages/devqubit-ui/src/devqubit_ui/templates/group_detail.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/group_detail.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}Group {{ group_id | short_id }} - devqubit{% endblock %}
+{% block title %}Group {{ group_id | short_id }} · devqubit{% endblock %}
 
 {% block content %}
 <div class="page-header">
     <div>
         <h1 class="page-title">Group <span class="font-mono">{{ group_id | short_id }}</span></h1>
-        <p class="text-muted text-sm">{{ group_id }}</p>
+        <p class="text-muted text-sm font-mono">{{ group_id }}</p>
     </div>
 </div>
 
@@ -19,7 +19,7 @@
         <thead>
             <tr>
                 <th>Run ID</th>
-                <th>Run Name</th>
+                <th>Name</th>
                 <th>Project</th>
                 <th>Status</th>
                 <th>Created</th>
@@ -28,7 +28,7 @@
         </thead>
         <tbody>
             {% for run in runs %}
-            <tr>
+            <tr id="run-row-{{ run.run_id }}">
                 <td>
                     <a href="/runs/{{ run.run_id }}" class="font-mono">
                         {{ run.run_id | short_id }}
@@ -41,13 +41,25 @@
                     <span class="badge badge-success">{{ run.status }}</span>
                     {% elif run.status == 'FAILED' %}
                     <span class="badge badge-danger">{{ run.status }}</span>
+                    {% elif run.status == 'RUNNING' %}
+                    <span class="badge badge-warning">{{ run.status }}</span>
                     {% else %}
                     <span class="badge badge-gray">{{ run.status }}</span>
                     {% endif %}
                 </td>
                 <td class="text-muted">{{ run.created_at | ago }}</td>
                 <td>
-                    <a href="/runs/{{ run.run_id }}" class="btn btn-sm btn-secondary">View</a>
+                    <div class="flex gap-1">
+                        <a href="/runs/{{ run.run_id }}" class="btn btn-sm btn-secondary">View</a>
+                        <button hx-delete="/api/runs/{{ run.run_id }}"
+                                hx-confirm="Delete run {{ run.run_id | short_id }}? This cannot be undone."
+                                hx-target="#run-row-{{ run.run_id }}"
+                                hx-swap="delete"
+                                class="btn btn-sm btn-ghost-danger"
+                                title="Delete run">
+                            Delete
+                        </button>
+                    </div>
                 </td>
             </tr>
             {% endfor %}

--- a/packages/devqubit-ui/src/devqubit_ui/templates/groups.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/groups.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Groups - devqubit{% endblock %}
+{% block title %}Groups · devqubit{% endblock %}
 
 {% block content %}
 <div class="page-header">
@@ -12,14 +12,17 @@
           hx-target="#groups-table"
           hx-swap="innerHTML"
           hx-indicator="#loading-indicator">
-        <!-- Preserve workspace on HTMX requests -->
         {% if current_workspace %}
         <input type="hidden" name="workspace" value="{{ current_workspace.id }}">
         {% endif %}
         <div class="form-row">
             <div class="form-group">
                 <label for="project">Project</label>
-                <select name="project" id="project" hx-trigger="change" hx-get="/groups" hx-target="#groups-table" hx-include="[name='workspace']">
+                <select name="project" id="project"
+                        hx-trigger="change"
+                        hx-get="/groups"
+                        hx-target="#groups-table"
+                        hx-include="[name='workspace']">
                     <option value="">All projects</option>
                     {% for p in projects %}
                     <option value="{{ p }}" {% if filters.project == p %}selected{% endif %}>{{ p }}</option>

--- a/packages/devqubit-ui/src/devqubit_ui/templates/projects.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/projects.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Projects - devqubit{% endblock %}
+{% block title %}Projects · devqubit{% endblock %}
 
 {% block content %}
 <div class="page-header">

--- a/packages/devqubit-ui/src/devqubit_ui/templates/run_detail.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/run_detail.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}Run {{ run.run_id | short_id }}{% if run.run_name %} — {{ run.run_name }}{% endif %} - devqubit{% endblock %}
+{% block title %}Run {{ run.run_id | short_id }}{% if run.run_name %} — {{ run.run_name }}{% endif %} · devqubit{% endblock %}
 
 {% block content %}
 <div class="page-header">
     <div>
         <h1 class="page-title">
-            {{ run.run_name or 'Unnamed run' }}
+            {{ run.run_name or 'Unnamed Run' }}
             {% if is_baseline %}
             <span class="badge badge-info">Baseline</span>
             {% endif %}
@@ -28,6 +28,9 @@
             Compare to Baseline
         </a>
         {% endif %}
+        <button onclick="showDeleteModal()" class="btn btn-ghost-danger btn-sm" title="Delete run">
+            Delete
+        </button>
     </div>
 </div>
 
@@ -184,7 +187,7 @@
 {% if errors %}
 <div class="card">
     <div class="card-header">
-        <h3 class="card-title" style="color: var(--danger);">Errors</h3>
+        <h3 class="card-title text-danger">Errors</h3>
     </div>
     {% for error in errors %}
     <div class="mb-1">
@@ -196,4 +199,51 @@
     {% endfor %}
 </div>
 {% endif %}
+
+<!-- Delete Confirmation Modal -->
+<div id="delete-modal" class="modal-backdrop">
+    <div class="modal">
+        <h3 class="modal-title">Delete Run</h3>
+        <div class="modal-body">
+            <p>Are you sure you want to delete this run?</p>
+            <p class="font-mono text-sm mt-1">{{ run.run_id | short_id }}</p>
+            <p class="text-sm text-danger mt-1">This action cannot be undone.</p>
+        </div>
+        <div class="modal-actions">
+            <button onclick="hideDeleteModal()" class="btn btn-secondary">Cancel</button>
+            <button hx-delete="/api/runs/{{ run.run_id }}"
+                    hx-indicator="#delete-spinner"
+                    class="btn btn-danger">
+                <span id="delete-spinner" class="htmx-indicator"><span class="spinner"></span></span>
+                Delete
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function showDeleteModal() {
+    document.getElementById('delete-modal').classList.add('active');
+}
+
+function hideDeleteModal() {
+    document.getElementById('delete-modal').classList.remove('active');
+}
+
+// Close modal on backdrop click
+document.getElementById('delete-modal').addEventListener('click', function(e) {
+    if (e.target === this) {
+        hideDeleteModal();
+    }
+});
+
+// Close modal on Escape key
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        hideDeleteModal();
+    }
+});
+</script>
 {% endblock %}

--- a/packages/devqubit-ui/src/devqubit_ui/templates/runs.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/runs.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Runs - devqubit{% endblock %}
+{% block title %}Runs · devqubit{% endblock %}
 
 {% block content %}
 <div class="page-header">
@@ -12,14 +12,17 @@
           hx-target="#runs-table"
           hx-swap="innerHTML"
           hx-indicator="#loading-indicator">
-        <!-- Preserve workspace on HTMX requests -->
         {% if current_workspace %}
         <input type="hidden" name="workspace" value="{{ current_workspace.id }}">
         {% endif %}
         <div class="form-row">
             <div class="form-group">
                 <label for="project">Project</label>
-                <select name="project" id="project" hx-trigger="change" hx-get="/runs" hx-target="#runs-table" hx-include="[name='workspace'], [name='status'], [name='limit'], [name='q']">
+                <select name="project" id="project"
+                        hx-trigger="change"
+                        hx-get="/runs"
+                        hx-target="#runs-table"
+                        hx-include="[name='workspace'], [name='status'], [name='limit'], [name='q']">
                     <option value="">All projects</option>
                     {% for p in projects %}
                     <option value="{{ p }}" {% if filters.project == p %}selected{% endif %}>{{ p }}</option>
@@ -28,7 +31,11 @@
             </div>
             <div class="form-group">
                 <label for="status">Status</label>
-                <select name="status" id="status" hx-trigger="change" hx-get="/runs" hx-target="#runs-table" hx-include="[name='workspace'], [name='project'], [name='limit'], [name='q']">
+                <select name="status" id="status"
+                        hx-trigger="change"
+                        hx-get="/runs"
+                        hx-target="#runs-table"
+                        hx-include="[name='workspace'], [name='project'], [name='limit'], [name='q']">
                     <option value="">All</option>
                     <option value="FINISHED" {% if filters.status == 'FINISHED' %}selected{% endif %}>Finished</option>
                     <option value="FAILED" {% if filters.status == 'FAILED' %}selected{% endif %}>Failed</option>
@@ -56,9 +63,7 @@
                 </select>
             </div>
             <div class="form-group" style="display: flex; align-items: flex-end; gap: 0.5rem;">
-                <button type="submit" class="btn btn-primary">
-                    Filter
-                </button>
+                <button type="submit" class="btn btn-primary">Filter</button>
                 <span id="loading-indicator" class="htmx-indicator">
                     <span class="spinner"></span>
                 </span>

--- a/packages/devqubit-ui/src/devqubit_ui/templates/search.html
+++ b/packages/devqubit-ui/src/devqubit_ui/templates/search.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Search - devqubit{% endblock %}
+{% block title %}Search · devqubit{% endblock %}
 
 {% block content %}
 <div class="page-header">
@@ -13,7 +13,6 @@
           hx-target="#search-results"
           hx-swap="innerHTML"
           hx-indicator="#search-indicator">
-        <!-- Preserve workspace on search -->
         {% if current_workspace %}
         <input type="hidden" name="workspace" value="{{ current_workspace.id }}">
         {% endif %}
@@ -23,7 +22,7 @@
                    name="q"
                    id="q"
                    placeholder="metric.fidelity > 0.95 and params.shots = 1000"
-                   style="font-family: monospace;"
+                   class="font-mono"
                    hx-trigger="keyup changed delay:500ms"
                    hx-get="/runs"
                    hx-target="#search-results"
@@ -119,7 +118,9 @@
         </tbody>
     </table>
 </div>
+{% endblock %}
 
+{% block scripts %}
 <script>
 // Show results container when search is active
 document.addEventListener('htmx:afterSwap', function(evt) {

--- a/packages/devqubit-ui/tests/conftest.py
+++ b/packages/devqubit-ui/tests/conftest.py
@@ -28,6 +28,7 @@ def mock_registry() -> Mock:
     registry.list_groups.return_value = []
     registry.count_runs.return_value = 0
     registry.get_baseline.return_value = None
+    registry.delete.return_value = True
     return registry
 
 

--- a/packages/devqubit-ui/tests/test_routers.py
+++ b/packages/devqubit-ui/tests/test_routers.py
@@ -186,3 +186,19 @@ class TestApiRouter:
             "/api/projects/test-project/baseline/test-run-123?redirect=false"
         )
         assert response.status_code == 400
+
+    def test_api_delete_run_success(self, client, mock_registry):
+        """Test successful run deletion."""
+        mock_registry.delete.return_value = True
+
+        response = client.delete("/api/runs/test-run-123")
+        assert response.status_code == 200
+        assert response.headers.get("HX-Redirect") == "/runs"
+        mock_registry.delete.assert_called_once_with("test-run-123")
+
+    def test_api_delete_run_not_found(self, client, mock_registry):
+        """Test deletion of non-existent run."""
+        mock_registry.delete.return_value = False
+
+        response = client.delete("/api/runs/nonexistent-id")
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
Add ability to delete runs from the UI. Users can delete runs either from the run detail page (with confirmation modal) or directly from runs tables via inline delete buttons.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no user-facing change)
- [ ] Docs only
- [ ] CI/build tooling
- [ ] Breaking change

## Related issues / context
Exposes existing `registry.delete()` method through the UI.

## Changelog (user-facing only)
- [x] I added a towncrier fragment in `changelog.d/`

## Checklist
- [x] I ran lint locally (`uv run pre-commit run --all-files`)
- [x] I ran tests locally (`uv run pytest`)
- [x] I added/updated tests for behavior changes
- [ ] I updated docs/README/examples if needed
- [ ] If I changed dependencies, I updated `uv.lock` (`uv lock`) and committed it
- [x] I considered backward compatibility and security impact