### PR TITLE
feat: DataFrame export & gc convenience command

### DIFF
--- a/packages/devqubit-engine/src/devqubit_engine/dataframe.py
+++ b/packages/devqubit-engine/src/devqubit_engine/dataframe.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 devqubit
+
+"""
+Convert runs to tabular DataFrames.
+
+Provides :func:`runs_to_dataframe` which loads runs from the registry,
+flattens nested params/metrics/tags into dot-prefixed columns, and
+returns a ``pandas.DataFrame``.
+
+Requires ``pandas`` — install with ``pip install devqubit[pandas]``.
+
+Examples
+--------
+>>> from devqubit_engine.dataframe import runs_to_dataframe
+>>> df = runs_to_dataframe(registry, project="vqe", limit=200)
+>>> df.columns
+Index(['run_id', 'run_name', 'project', ..., 'param.shots', 'metric.fidelity'])
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from devqubit_engine.storage.types import RegistryProtocol
+
+logger = logging.getLogger(__name__)
+
+
+def _require_pandas() -> Any:
+    """Import pandas or raise a clear error."""
+    try:
+        import pandas
+
+        return pandas
+    except ImportError:
+        raise ImportError(
+            "pandas is required for DataFrame export. "
+            "Install it with: pip install devqubit[pandas]"
+        ) from None
+
+
+def _flatten_record(record: Any) -> dict[str, Any]:
+    """Flatten a RunRecord into a single dict row.
+
+    Standard columns are always present (possibly ``None``).
+    Dynamic columns use dotted prefixes: ``param.*``, ``metric.*``, ``tag.*``.
+    """
+    row: dict[str, Any] = {
+        "run_id": record.run_id,
+        "run_name": record.run_name,
+        "project": record.project,
+        "adapter": record.adapter,
+        "status": record.status,
+        "created_at": record.created_at or None,
+        "ended_at": record.ended_at,
+        "group_id": record.group_id,
+        "group_name": record.group_name,
+        "backend_name": record.backend_name,
+    }
+
+    for key, value in record.params.items():
+        row[f"param.{key}"] = value
+
+    for key, value in record.metrics.items():
+        row[f"metric.{key}"] = value
+
+    for key, value in record.tags.items():
+        row[f"tag.{key}"] = value
+
+    return row
+
+
+def runs_to_dataframe(
+    registry: RegistryProtocol,
+    *,
+    project: str | None = None,
+    group_id: str | None = None,
+    status: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int = 1000,
+) -> pd.DataFrame:
+    """
+    Load runs from the registry and return a flat DataFrame.
+
+    Each run becomes one row.  Standard fields (``run_id``, ``project``,
+    ``status``, …) are always present.  Params, metrics, and tags are
+    expanded into ``param.*``, ``metric.*``, and ``tag.*`` columns.
+
+    Parameters
+    ----------
+    registry : RegistryProtocol
+        Registry to query.
+    project : str, optional
+        Filter by project name.
+    group_id : str, optional
+        Filter by group ID (for sweep/experiment aggregation).
+    status : str, optional
+        Filter by status (``FINISHED``, ``FAILED``, ``RUNNING``, ``KILLED``).
+    since : str, optional
+        Only include runs created after this ISO 8601 datetime.
+    until : str, optional
+        Only include runs created before this ISO 8601 datetime.
+    limit : int, default 1000
+        Maximum number of runs to load.
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per run, columns sorted: standard fields first,
+        then ``metric.*``, ``param.*``, ``tag.*`` alphabetically.
+
+    Raises
+    ------
+    ImportError
+        If ``pandas`` is not installed.
+
+    Examples
+    --------
+    >>> df = runs_to_dataframe(registry, project="vqe")
+    >>> df[["run_id", "metric.fidelity", "param.shots"]].head()
+
+    >>> # Group aggregation
+    >>> df = runs_to_dataframe(registry, group_id="sweep_20260115")
+    >>> df.groupby("param.optimization_level")["metric.fidelity"].mean()
+    """
+    pd = _require_pandas()
+
+    # Fetch run summaries with pagination
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    batch_size = min(limit, 500)
+
+    while len(rows) < limit:
+        remaining = min(batch_size, limit - len(rows))
+        summaries = registry.list_runs(
+            limit=remaining,
+            offset=offset,
+            project=project,
+            group_id=group_id,
+            status=status,
+            created_after=since,
+            created_before=until,
+        )
+        if not summaries:
+            break
+
+        for summary in summaries:
+            run_id = summary.get("run_id", "")
+            if not run_id:
+                continue
+            try:
+                record = registry.load(run_id)
+                rows.append(_flatten_record(record))
+            except Exception as exc:
+                logger.warning("Skipping run %s: %s", run_id, exc)
+
+        offset += len(summaries)
+        if len(summaries) < remaining:
+            break
+
+    if not rows:
+        # Return empty DataFrame with standard columns
+        return pd.DataFrame(
+            columns=[
+                "run_id",
+                "run_name",
+                "project",
+                "adapter",
+                "status",
+                "created_at",
+                "ended_at",
+                "group_id",
+                "group_name",
+                "backend_name",
+            ]
+        )
+
+    df = pd.DataFrame(rows)
+
+    # Sort columns: standard fields first, then dynamic fields alphabetically
+    standard = [
+        "run_id",
+        "run_name",
+        "project",
+        "adapter",
+        "status",
+        "created_at",
+        "ended_at",
+        "group_id",
+        "group_name",
+        "backend_name",
+    ]
+    present_standard = [c for c in standard if c in df.columns]
+    dynamic = sorted(c for c in df.columns if c not in standard)
+    df = df[present_standard + dynamic]
+
+    return df

--- a/packages/devqubit-engine/tests/test_dataframe.py
+++ b/packages/devqubit-engine/tests/test_dataframe.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 devqubit
+
+"""Tests for devqubit_engine.dataframe."""
+
+from __future__ import annotations
+
+import pytest
+from devqubit_engine.dataframe import _flatten_record, runs_to_dataframe
+
+
+pd = pytest.importorskip("pandas")
+
+
+class TestFlattenRecord:
+    def test_standard_fields(self, run_factory):
+        rec = run_factory(run_id="r-1", project="proj", status="FINISHED")
+        row = _flatten_record(rec)
+        assert row["run_id"] == "r-1"
+        assert row["project"] == "proj"
+        assert row["status"] == "FINISHED"
+        assert row["backend_name"] == "test_backend"
+
+    def test_params_prefixed(self, run_factory):
+        rec = run_factory(params={"shots": 1000, "opt_level": 3})
+        row = _flatten_record(rec)
+        assert row["param.shots"] == 1000
+        assert row["param.opt_level"] == 3
+
+    def test_metrics_prefixed(self, run_factory):
+        rec = run_factory(metrics={"fidelity": 0.95, "tvd": 0.02})
+        row = _flatten_record(rec)
+        assert row["metric.fidelity"] == 0.95
+        assert row["metric.tvd"] == 0.02
+
+    def test_tags_prefixed(self, run_factory):
+        rec = run_factory(tags={"device": "ibm_kyoto"})
+        row = _flatten_record(rec)
+        assert row["tag.device"] == "ibm_kyoto"
+
+    def test_running_has_null_ended_at(self, run_factory):
+        rec = run_factory(status="RUNNING")
+        row = _flatten_record(rec)
+        assert row["ended_at"] is None
+
+
+class TestRunsToDataframe:
+    def test_basic(self, registry, run_factory):
+        for i, fid in enumerate([0.9, 0.95]):
+            rec = run_factory(
+                run_id=f"run-{i}",
+                project="vqe",
+                metrics={"fidelity": fid},
+            )
+            registry.save(rec.record)
+
+        df = runs_to_dataframe(registry, project="vqe")
+        assert len(df) == 2
+        assert "metric.fidelity" in df.columns
+        assert set(df["run_id"]) == {"run-0", "run-1"}
+
+    def test_empty(self, registry):
+        df = runs_to_dataframe(registry)
+        assert len(df) == 0
+        assert "run_id" in df.columns
+        assert "status" in df.columns
+
+    def test_column_order(self, registry, run_factory):
+        rec = run_factory(
+            run_id="r-order",
+            params={"z_param": 1, "a_param": 2},
+            metrics={"z_metric": 0.5},
+            tags={"a_tag": "x"},
+        )
+        registry.save(rec.record)
+
+        df = runs_to_dataframe(registry)
+        cols = list(df.columns)
+        # Standard columns come first
+        assert cols[0] == "run_id"
+        # Dynamic columns sorted alphabetically
+        dynamic = [c for c in cols if "." in c]
+        assert dynamic == sorted(dynamic)
+
+    def test_heterogeneous_columns(self, registry, run_factory):
+        """Runs with different params produce NaN for missing."""
+        r1 = run_factory(run_id="r-het-1", params={"shots": 1000})
+        r2 = run_factory(run_id="r-het-2", params={"depth": 5})
+        registry.save(r1.record)
+        registry.save(r2.record)
+
+        df = runs_to_dataframe(registry)
+        assert pd.isna(df.loc[df["run_id"] == "r-het-1", "param.depth"].iloc[0])
+        assert pd.isna(df.loc[df["run_id"] == "r-het-2", "param.shots"].iloc[0])
+
+    def test_project_filter(self, registry, run_factory):
+        for i, proj in enumerate(["vqe", "bell", "vqe"]):
+            rec = run_factory(run_id=f"r-pf-{i}", project=proj)
+            registry.save(rec.record)
+
+        df = runs_to_dataframe(registry, project="vqe")
+        assert len(df) == 2
+        assert all(df["project"] == "vqe")
+
+    def test_status_filter(self, registry, run_factory):
+        for i, st in enumerate(["FINISHED", "FAILED", "FINISHED"]):
+            rec = run_factory(run_id=f"r-st-{i}", status=st)
+            registry.save(rec.record)
+
+        df = runs_to_dataframe(registry, status="FAILED")
+        assert len(df) == 1
+        assert df.iloc[0]["status"] == "FAILED"
+
+    def test_group_filter(self, registry, run_factory):
+        r1 = run_factory(run_id="r-g1", group_id="sweep-1")
+        r2 = run_factory(run_id="r-g2", group_id="sweep-2")
+        r3 = run_factory(run_id="r-g3", group_id="sweep-1")
+        for r in [r1, r2, r3]:
+            registry.save(r.record)
+
+        df = runs_to_dataframe(registry, group_id="sweep-1")
+        assert set(df["run_id"]) == {"r-g1", "r-g3"}
+
+    def test_limit(self, registry, run_factory):
+        for i in range(10):
+            rec = run_factory(run_id=f"r-lim-{i:02d}")
+            registry.save(rec.record)
+
+        df = runs_to_dataframe(registry, limit=3)
+        assert len(df) == 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
     "black[jupyter]>=25.12.0",
     "ipykernel>=7.1.0",
     "isort>=7.0.0",
+    "pandas>=2.3.3",
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
     "responses>=0.25.8",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -788,6 +788,7 @@ dev = [
     { name = "black", extra = ["jupyter"] },
     { name = "ipykernel" },
     { name = "isort" },
+    { name = "pandas" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "responses" },
@@ -825,6 +826,7 @@ dev = [
     { name = "black", extras = ["jupyter"], specifier = ">=25.12.0" },
     { name = "ipykernel", specifier = ">=7.1.0" },
     { name = "isort", specifier = ">=7.0.0" },
+    { name = "pandas", specifier = ">=2.3.3" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "responses", specifier = ">=0.25.8" },


### PR DESCRIPTION
## Summary
Add `runs_to_dataframe()` for programmatic run analysis and a top-level `devqubit gc` command that combines `prune_runs()` + `gc_run()` in one step.

## Type of change
- [x] New feature

## Checklist
- [x] I ran lint locally (`uv run pre-commit run --all-files`)
- [x] I ran tests locally (`uv run pytest`)
- [x] I added/updated tests for behavior changes
- [x] If I changed dependencies, I updated `uv.lock` (`uv lock`) and committed it
- [x] I considered backward compatibility and security impact

## Notes for reviewers
- `pandas` is optional: `pip install devqubit[pandas]`. Import guarded with clear error message.
- `devqubit gc` without `--older-than` only cleans orphaned objects (safe no-op on runs). With `--older-than` it prunes first, then re-scans for new orphans.