### PR TITLE
feat: add devqubit-divi adapter for Qoro Divi

### DIFF
--- a/examples/01_vqe_optimization_qiskit.ipynb
+++ b/examples/01_vqe_optimization_qiskit.ipynb
@@ -111,6 +111,29 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 🌐 Launch Web UI (Optional)\n",
+    "\n",
+    "Start the devqubit web UI **now** to watch experiments appear in real time as you run the cells below.\n",
+    "\n",
+    "> Run the cell below, then open the URL in a browser and keep it open while you execute the rest of the notebook.\n",
+    "> New runs will appear automatically after each experiment completes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from devqubit.ui import run_server\n",
+    "\n",
+    "run_server(workspace=str(WORKSPACE))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section-1",
    "metadata": {},
    "source": [
@@ -350,6 +373,7 @@
     "for cfg in sweep_configs:\n",
     "    with track(\n",
     "        project=PROJECT,\n",
+    "        run_name=cfg[\"name\"],\n",
     "        group_id=\"optimizer_sweep\",\n",
     "        group_name=\"Optimizer Comparison\",\n",
     "    ) as run:\n",

--- a/examples/02_qml_classification_pennylane.ipynb
+++ b/examples/02_qml_classification_pennylane.ipynb
@@ -99,6 +99,29 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 🌐 Launch Web UI (Optional)\n",
+    "\n",
+    "Start the devqubit web UI **now** to watch experiments appear in real time as you run the cells below.\n",
+    "\n",
+    "> Run the cell below, then open the URL in a browser and keep it open while you execute the rest of the notebook.\n",
+    "> New runs will appear automatically after each experiment completes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from devqubit.ui import run_server\n",
+    "\n",
+    "run_server(workspace=str(WORKSPACE))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section-1",
    "metadata": {},
    "source": [
@@ -444,7 +467,10 @@
     "\n",
     "for arch_name, builder, n_layers in architectures:\n",
     "    with track(\n",
-    "        project=PROJECT, group_id=\"arch_sweep\", group_name=\"Architecture Comparison\"\n",
+    "        project=PROJECT,\n",
+    "        run_name=f\"{arch_name}_L{n_layers}\",\n",
+    "        group_id=\"arch_sweep\",\n",
+    "        group_name=\"Architecture Comparison\",\n",
     "    ) as run:\n",
     "        dev = qml.device(\"default.qubit\", wires=N_QUBITS)\n",
     "        tracked_dev = run.wrap(dev)\n",

--- a/examples/03_noise_analysis_cirq.ipynb
+++ b/examples/03_noise_analysis_cirq.ipynb
@@ -91,6 +91,29 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 🌐 Launch Web UI (Optional)\n",
+    "\n",
+    "Start the devqubit web UI **now** to watch experiments appear in real time as you run the cells below.\n",
+    "\n",
+    "> Run the cell below, then open the URL in a browser and keep it open while you execute the rest of the notebook.\n",
+    "> New runs will appear automatically after each experiment completes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from devqubit.ui import run_server\n",
+    "\n",
+    "run_server(workspace=str(WORKSPACE))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section-1",
    "metadata": {},
    "source": [
@@ -254,6 +277,7 @@
     "for cfg in noise_configs:\n",
     "    with track(\n",
     "        project=PROJECT,\n",
+    "        run_name=f\"{cfg['type']}_p{cfg['rate']}\",\n",
     "        group_id=\"noise_sweep\",\n",
     "        group_name=\"Noise Model Comparison\",\n",
     "    ) as run:\n",
@@ -371,6 +395,7 @@
     "\n",
     "with track(\n",
     "    project=PROJECT,\n",
+    "    run_name=\"depth_scaling_depol\",\n",
     "    group_id=\"depth_sweep\",\n",
     "    group_name=\"Fidelity vs Depth\",\n",
     ") as run:\n",

--- a/examples/04_bundle_sharing_braket.ipynb
+++ b/examples/04_bundle_sharing_braket.ipynb
@@ -108,6 +108,29 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 🌐 Launch Web UI (Optional)\n",
+    "\n",
+    "Start the devqubit web UI **now** to watch experiments appear in real time as you run the cells below.\n",
+    "\n",
+    "> Run the cell below, then open the URL in a browser and keep it open while you execute the rest of the notebook.\n",
+    "> New runs will appear automatically after each experiment completes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from devqubit.ui import run_server\n",
+    "\n",
+    "run_server(workspace=str(LOCAL_ROOT))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section-1",
    "metadata": {},
    "source": [

--- a/examples/05_drift_detection_runtime.ipynb
+++ b/examples/05_drift_detection_runtime.ipynb
@@ -136,6 +136,29 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 🌐 Launch Web UI (Optional)\n",
+    "\n",
+    "Start the devqubit web UI **now** to watch experiments appear in real time as you run the cells below.\n",
+    "\n",
+    "> Run the cell below, then open the URL in a browser and keep it open while you execute the rest of the notebook.\n",
+    "> New runs will appear automatically after each experiment completes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from devqubit.ui import run_server\n",
+    "\n",
+    "run_server(workspace=str(WORKSPACE))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section-1",
    "metadata": {},
    "source": [
@@ -289,10 +312,11 @@
     "    circuit: QuantumCircuit,\n",
     "    params: dict,\n",
     "    tags: dict,\n",
+    "    run_name: str | None = None,\n",
     ") -> str:\n",
     "    \"\"\"Execute benchmark with full devqubit tracking.\"\"\"\n",
     "\n",
-    "    with track(project=project) as run:\n",
+    "    with track(project=project, run_name=run_name) as run:\n",
     "        # Wrap the sampler to capture execution context\n",
     "        tracked_sampler = run.wrap(sampler)\n",
     "\n",
@@ -329,6 +353,7 @@
     "    project=PROJECT,\n",
     "    sampler=baseline_sampler,\n",
     "    circuit=circuit_isa,\n",
+    "    run_name=\"baseline\",\n",
     "    params={\n",
     "        \"circuit_name\": \"calibration_benchmark\",\n",
     "        \"n_qubits\": N_QUBITS,\n",
@@ -491,6 +516,7 @@
     "        project=PROJECT,\n",
     "        sampler=sampler,\n",
     "        circuit=circuit_isa,\n",
+    "        run_name=sc[\"name\"],\n",
     "        params={\n",
     "            \"circuit_name\": \"calibration_benchmark\",\n",
     "            \"n_qubits\": N_QUBITS,\n",

--- a/examples/06_ghz_and_vqe_cudaq.ipynb
+++ b/examples/06_ghz_and_vqe_cudaq.ipynb
@@ -96,6 +96,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### 🌐 Launch Web UI (Optional)\n",
+    "\n",
+    "Start the devqubit web UI **now** to watch experiments appear in real time as you run the cells below.\n",
+    "\n",
+    "> Run the cell below, then open the URL in a browser and keep it open while you execute the rest of the notebook.\n",
+    "> New runs will appear automatically after each experiment completes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from devqubit.ui import run_server\n",
+    "\n",
+    "run_server(workspace=str(WORKSPACE))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "---\n",
     "## Part A: GHZ Population Scaling\n",
     "\n",

--- a/examples/07_ui_demo.ipynb
+++ b/examples/07_ui_demo.ipynb
@@ -130,6 +130,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### 🌐 Launch Web UI\n",
+    "\n",
+    "Start the devqubit web UI **now** and keep it open — you'll see experiments appear in real time as you run the cells below.\n",
+    "\n",
+    "The UI provides:\n",
+    "- **Runs list** — Browse all experiments with filtering\n",
+    "- **Run details** — View parameters, metrics, and artifacts\n",
+    "- **Comparison** — Diff two runs side-by-side\n",
+    "- **Groups** — Navigate experiment sweeps\n",
+    "- **Projects** — Overview of all projects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from devqubit.ui import run_server\n",
+    "\n",
+    "run_server(workspace=str(WORKSPACE))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Get Available Backends\n",
     "\n",
     "We'll use a mix of ideal (AerSimulator) and noisy (fake backends) simulators to demonstrate how devqubit tracks experiments across different execution environments."
@@ -756,38 +783,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 9. Launch the Web UI\n",
-    "\n",
-    "Now let's launch the devqubit web UI to explore our experiments visually!\n",
-    "\n",
-    "The UI provides:\n",
-    "- **Runs list** — Browse all experiments with filtering\n",
-    "- **Run details** — View parameters, metrics, and artifacts\n",
-    "- **Comparison** — Diff two runs side-by-side\n",
-    "- **Groups** — Navigate experiment sweeps\n",
-    "- **Projects** — Overview of all projects\n",
-    "\n",
-    "### ⚠️ Note\n",
-    "Running the cell below will start a web server. The cell will block until you stop the server (interrupt the kernel)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from devqubit.ui import run_server\n",
-    "\n",
-    "run_server(workspace=str(WORKSPACE))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 10. Cleanup (Optional)\n",
+    "## 9. Cleanup (Optional)\n",
     "\n",
     "Run this cell to remove the demo workspace:"
    ]

--- a/packages/devqubit-divi/LICENSE
+++ b/packages/devqubit-divi/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/devqubit-divi/README.md
+++ b/packages/devqubit-divi/README.md
@@ -1,0 +1,64 @@
+# devqubit-divi
+
+Qoro Divi adapter for [devqubit](https://github.com/devqubit-labs/devqubit).
+
+> [!IMPORTANT]
+> **This is an internal adapter package.** Install via `pip install "devqubit[cudaq]"` and use the `devqubit` public API.
+
+## Installation
+
+```bash
+pip install "devqubit[cudaq]"
+```
+
+## Usage
+
+### Sampling
+
+```python
+import cudaq
+from devqubit import track
+
+@cudaq.kernel
+def bell():
+    q = cudaq.qvector(2)
+    h(q[0])
+    x.ctrl(q[0], q[1])
+    mz(q)
+
+with track(project="cudaq-experiment") as run:
+    executor = run.wrap(cudaq)
+    result = executor.sample(bell, shots_count=1000)
+```
+
+### Observe (Expectation Values)
+
+```python
+from cudaq import spin
+
+hamiltonian = spin.z(0)
+
+with track(project="cudaq-vqe") as run:
+    executor = run.wrap(cudaq)
+    result = executor.observe(bell, hamiltonian)
+    print(result.expectation())
+```
+
+## What's Captured
+
+| Artifact | Kind | Role |
+|---|---|---|
+| Kernel JSON | `cudaq.kernel.json` | `program` |
+| Kernel diagram | `cudaq.kernel.diagram` | `program` |
+| MLIR (Quake) | `cudaq.kernel.mlir` | `program` |
+| QIR | `cudaq.kernel.qir` | `program` |
+| Counts / expectation | `result.cudaq.output.json` | `result` |
+| Execution envelope | `devqubit.envelope.json` | `envelope` |
+
+## Documentation
+
+See the [Adapters guide](https://devqubit.readthedocs.io/en/latest/guides/adapters.html) for details on `observe` workflows, performance tuning, and spin operator capture.
+
+## License
+
+Apache 2.0

--- a/packages/devqubit-divi/pyproject.toml
+++ b/packages/devqubit-divi/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["hatchling>=1.26"]
+build-backend = "hatchling.build"
+
+[project]
+name = "devqubit-divi"
+version = "0.1.12"
+description = "devqubit adapter for Qoro Divi"
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+requires-python = ">=3.11,<3.14"
+
+authors = [{ name = "devqubit" }]
+keywords = ["quantum", "divi", "experiment-tracking"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+
+dependencies = [
+    "devqubit-engine>=0.1.12,<0.2.0",
+]
+
+[project.entry-points."devqubit.adapters"]
+divi = "devqubit_divi.adapter:DiviAdapter"
+
+[project.entry-points."devqubit.circuit.loaders"]
+divi = "devqubit_divi.serialization:DiviCircuitLoader"
+
+[project.entry-points."devqubit.circuit.serializers"]
+divi = "devqubit_divi.serialization:DiviCircuitSerializer"
+
+[project.entry-points."devqubit.circuit.summarizers"]
+divi = "devqubit_divi.serialization:summarize_divi_circuit"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/devqubit_divi"]
+
+[tool.uv.sources]
+devqubit-engine = { workspace = true }


### PR DESCRIPTION
## Draft PR: `devqubit-divi` adapter (Divi backend/workflow tracking)
Related to:
- #51 

### Context
Divi generates and executes batches of OpenQASM2 circuits across multiple backend types (e.g. local simulators and cloud hardware/services). This PR is a **draft placeholder** to start the integration with `devqubit-engine` and make execution tracking visible early.

### MVP scope (this PR)
- Introduce a `devqubit-divi` adapter that **wraps Divi backends** by intercepting
- Emit a `ExecutionEnvelope` (UEC-style) with the minimum useful snapshots:
  - **DeviceSnapshot**: backend/provider/type + SDK versions
  - **ProgramSnapshot**: `label -> qasm` manifest + stable QASM hashes
  - **ExecutionSnapshot**: timestamps, shots, job_id + sanitized options
  - **ResultSnapshot**: always attach raw results as an artifact; best-effort normalization to COUNTS / EXPECTATION when recognizable
- Support **pending** runs (envelope marked pending if results weren’t fetched yet) and **failure envelopes** with traceback.